### PR TITLE
Implement `GasBurner` for structures that implement `nonfungibles`.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+  "rust-analyzer.lens.references.trait.enable": true,
+  "rust-analyzer.checkOnSave": true,
+  "rust-analyzer.cargo.features": [
+    "runtime-benchmarks",
+  ],
+  "rust-analyzer.showUnlinkedFileNotification": false,
+  "rust-analyzer.rustfmt.extraArgs": [
+    "+stable"
+  ],
+  "[rust]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "rust-lang.rust-analyzer"
+  },
+  "[toml]": {
+    "editor.formatOnSave": false
+  }
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,6 +1114,13 @@ name = "fc-traits-gas-tank"
 version = "0.1.0"
 dependencies = [
  "frame-support",
+ "frame-system",
+ "pallet-balances",
+ "pallet-nfts",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]

--- a/traits/gas-tank/Cargo.toml
+++ b/traits/gas-tank/Cargo.toml
@@ -7,10 +7,26 @@ repository.workspace = true
 version = "0.1.0"
 
 [dependencies]
-frame-support = {workspace = true}
+codec.workspace = true
+frame-support.workspace = true
+frame-system.workspace = true
+sp-runtime.workspace = true
+
+[dev-dependencies]
+pallet-balances.workspace = true
+pallet-nfts.workspace = true
+scale-info.workspace = true
+sp-io.workspace = true
 
 [features]
 default = ["std"]
 std = [
+  "codec/std",
+  "pallet-balances/std",
+  "pallet-nfts/std",
   "frame-support/std",
+  "frame-system/std",
+  "scale-info/std",
+  "sp-io/std",
+  "sp-runtime/std",
 ]

--- a/traits/gas-tank/src/impl_nonfungibles.rs
+++ b/traits/gas-tank/src/impl_nonfungibles.rs
@@ -83,34 +83,27 @@ where
     }
 
     fn burn_gas(who: &Self::AccountId, expected: &Self::Gas, used: &Self::Gas) -> Self::Gas {
-        let Some(mut gas_tank): Option<MembershipWeightTank<T>> =
-            F::owned(who).find_map(|(collection, item)| {
-                let expected_remaining: Weight = F::typed_system_attribute(
+        F::owned(who)
+            .find_map(|(collection, item)| {
+                if !expected.eq(&F::typed_system_attribute(
                     &collection,
                     Some(&item),
                     &ATTR_GAS_TX_PAY_WITH_MEMBERSHIP,
-                )?;
-
-                if expected.eq(&expected_remaining) {
-                    Some(F::typed_system_attribute(
-                        &collection,
-                        Some(&item),
-                        &ATTR_MEMBERSHIP_GAS,
-                    )?)
-                } else {
-                    None
+                )?) {
+                    return None;
                 }
+                F::clear_typed_attribute(&collection, &item, &ATTR_GAS_TX_PAY_WITH_MEMBERSHIP)
+                    .ok()?;
+
+                let mut gas_tank: MembershipWeightTank<T> =
+                    F::typed_system_attribute(&collection, Some(&item), &ATTR_MEMBERSHIP_GAS)?;
+
+                gas_tank.used = gas_tank.used.checked_add(used)?;
+
+                F::set_typed_attribute(&collection, &item, &ATTR_MEMBERSHIP_GAS, &gas_tank).ok()?;
+                let max_weight = gas_tank.max_per_period?;
+                Some(max_weight.saturating_sub(gas_tank.used))
             })
-        else {
-            return Weight::zero();
-        };
-        let Some(max_weight) = gas_tank.max_per_period else {
-            return Weight::MAX;
-        };
-
-        gas_tank.used = gas_tank.used.add_proof_size(used.proof_size());
-        gas_tank.used = gas_tank.used.add_ref_time(used.ref_time());
-
-        max_weight.saturating_sub(gas_tank.used)
+            .unwrap_or_default()
     }
 }

--- a/traits/gas-tank/src/impl_nonfungibles.rs
+++ b/traits/gas-tank/src/impl_nonfungibles.rs
@@ -1,0 +1,69 @@
+use core::marker::PhantomData;
+
+use frame_support::{
+    pallet_prelude::{Decode, Encode},
+    traits::{nonfungibles_v2, ConstU32, Get},
+    weights::Weight,
+    BoundedBTreeMap,
+};
+
+use crate::*;
+
+pub const ATTR_MEMBER_GAS_SIZE: &[u8] = b"membership_gas_size";
+pub type GasSizeConfigMap = BoundedBTreeMap<GasTankSize, Weight, ConstU32<3>>;
+
+#[derive(Encode, Decode, PartialEq, Eq, PartialOrd, Ord, Debug)]
+pub enum GasTankSize {
+    Small,
+    Medium,
+    Large,
+}
+
+pub struct NonFungibleGasBurner<
+    T: frame_system::Config,
+    S: Get<GasSizeConfigMap>,
+    F: nonfungibles_v2::Inspect<T::AccountId> + nonfungibles_v2::InspectEnumerable<T::AccountId>,
+>(PhantomData<(S, T, F)>);
+
+impl<T, S, F> GasBurner for NonFungibleGasBurner<T, S, F>
+where
+    T: frame_system::Config,
+    S: Get<GasSizeConfigMap>,
+    F: nonfungibles_v2::Inspect<T::AccountId> + nonfungibles_v2::InspectEnumerable<T::AccountId>,
+    F::CollectionId: Into<u64> + TryFrom<u64>,
+    <F::CollectionId as TryFrom<u64>>::Error: core::fmt::Debug,
+    F::ItemId: Into<u64> + TryFrom<u64>,
+    <F::ItemId as TryFrom<u64>>::Error: core::fmt::Debug,
+{
+    type AccountId = T::AccountId;
+    type Gas = Weight;
+
+    fn check_available_gas(who: &Self::AccountId, estimated: &Self::Gas) -> Option<Self::Gas> {
+        F::owned(who)
+            .find(|(collection, item)| {
+                let Some(gas_size) =
+                    F::typed_system_attribute(collection, Some(item), &ATTR_MEMBER_GAS_SIZE)
+                else {
+                    return false;
+                };
+                let weight_configs = S::get().into_inner();
+                let Some(max_weight) = weight_configs.get(&gas_size) else {
+                    return false;
+                };
+
+                max_weight.checked_sub(estimated).is_some()
+            })
+            .map(|(collection, item)| {
+                // Note: This is a hacky trick to store the item ID into the expected leftover,
+                // which is returned back in `burn_gas` as `expected`
+                Weight::from_parts(collection.into(), item.into())
+            })
+    }
+
+    fn burn_gas(_: &Self::AccountId, _: &Self::Gas, _: &Self::Gas) -> Self::Gas {
+        // TODO: Implement this. This naive implementation won't burn gas. It
+        // will just check the gas tank from the item has enough size to cover
+        // the call.
+        Weight::from_parts(1, 1)
+    }
+}

--- a/traits/gas-tank/src/lib.rs
+++ b/traits/gas-tank/src/lib.rs
@@ -1,4 +1,11 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
 use frame_support::Parameter;
+
+#[cfg(test)]
+mod tests;
+
+mod impl_nonfungibles;
 
 pub trait GasTank: GasBurner + GasFueler {}
 

--- a/traits/gas-tank/src/tests.rs
+++ b/traits/gas-tank/src/tests.rs
@@ -1,0 +1,199 @@
+use super::*;
+
+use frame_support::{
+    assert_ok, derive_impl, parameter_types,
+    traits::{ConstU128, ConstU32},
+};
+use frame_system::EnsureNever;
+use impl_nonfungibles::{
+    GasSizeConfigMap, GasTankSize, NonFungibleGasBurner, ATTR_MEMBER_GAS_SIZE,
+};
+use sp_runtime::{
+    traits::{IdentifyAccount, IdentityLookup, Verify},
+    BoundedBTreeMap, MultiSignature,
+};
+
+type Block = frame_system::mocking::MockBlock<Test>;
+
+pub type AccountPublic = <MultiSignature as Verify>::Signer;
+pub type AccountId = <AccountPublic as IdentifyAccount>::AccountId;
+pub type Balance = u128;
+
+#[frame_support::runtime]
+mod runtime {
+    #[runtime::runtime]
+    #[runtime::derive(
+        RuntimeCall,
+        RuntimeEvent,
+        RuntimeError,
+        RuntimeOrigin,
+        RuntimeFreezeReason,
+        RuntimeHoldReason,
+        RuntimeSlashReason,
+        RuntimeLockId,
+        RuntimeTask
+    )]
+    pub struct Test;
+
+    #[runtime::pallet_index(0)]
+    pub type System = frame_system;
+
+    #[runtime::pallet_index(10)]
+    pub type Balances = pallet_balances;
+
+    #[runtime::pallet_index(20)]
+    pub type Memberships = pallet_nfts;
+}
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig as frame_system::DefaultConfig)]
+impl frame_system::Config for Test {
+    type AccountId = AccountId;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type Block = Block;
+    type AccountData = pallet_balances::AccountData<Balance>;
+}
+
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig as pallet_balances::DefaultConfig)]
+impl pallet_balances::Config for Test {
+    type AccountStore = System;
+    type Balance = Balance;
+    type ExistentialDeposit = ConstU128<1>;
+}
+
+impl pallet_nfts::Config for Test {
+    type ApprovalsLimit = ();
+    type AttributeDepositBase = ();
+    type CollectionDeposit = ();
+    type CollectionId = u16;
+    type CreateOrigin = EnsureNever<AccountId>;
+    type Currency = Balances;
+    type DepositPerByte = ();
+    type Features = ();
+    type ForceOrigin = EnsureNever<AccountId>;
+    type ItemAttributesApprovalsLimit = ();
+    type ItemDeposit = ();
+    type ItemId = u32;
+    type KeyLimit = ConstU32<64>;
+    type Locker = ();
+    type MaxAttributesPerCall = ();
+    type MaxDeadlineDuration = ();
+    type MaxTips = ();
+    type MetadataDepositBase = ();
+    type OffchainPublic = AccountPublic;
+    type OffchainSignature = MultiSignature;
+    type RuntimeEvent = RuntimeEvent;
+    type StringLimit = ();
+    type ValueLimit = ConstU32<10>;
+    type WeightInfo = ();
+
+    #[cfg(feature = "runtime-benchmarks")]
+    type Helper = ();
+}
+
+parameter_types! {
+    pub GasSizeConfigs: GasSizeConfigMap = {
+        let mut map = BoundedBTreeMap::new();
+
+        map.try_insert(GasTankSize::Small, <() as frame_system::WeightInfo>::remark(13))
+            .expect("given values are correct; qed");
+        map.try_insert(GasTankSize::Medium, <() as frame_system::WeightInfo>::remark(26))
+            .expect("given values are correct; qed");
+        map.try_insert(GasTankSize::Large, <() as frame_system::WeightInfo>::remark(39))
+            .expect("given values are correct; qed");
+
+        map
+    };
+}
+
+pub type MembershipsGas = NonFungibleGasBurner<Test, GasSizeConfigs, Memberships>;
+
+parameter_types! {
+    const CollectionOwner: AccountId = AccountId::new([0u8;32]);
+    const SmallMember: AccountId = AccountId::new([1u8;32]);
+    const MediumMember: AccountId = AccountId::new([2u8;32]);
+    const LargeMember: AccountId = AccountId::new([3u8;32]);
+}
+
+pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
+    use frame_support::traits::nonfungibles_v2::{Create, Mutate};
+
+    let collection_id = 1;
+    let mut ext = sp_io::TestExternalities::default();
+    ext.execute_with(|| {
+        assert_ok!(Memberships::create_collection_with_id(
+            collection_id,
+            &CollectionOwner::get(),
+            &CollectionOwner::get(),
+            &Default::default(),
+        ));
+
+        for (item, who, size) in [
+            (1, SmallMember::get(), GasTankSize::Small),
+            (2, MediumMember::get(), GasTankSize::Medium),
+            (3, LargeMember::get(), GasTankSize::Large),
+        ] {
+            assert_ok!(Memberships::mint_into(
+                &collection_id,
+                &item,
+                &who,
+                &Default::default(),
+                true,
+            ));
+            assert_ok!(Memberships::set_typed_attribute(
+                &collection_id,
+                &item,
+                &ATTR_MEMBER_GAS_SIZE,
+                &size
+            ));
+        }
+    });
+    ext
+}
+
+mod gas_burner {
+    use frame_support::weights::Weight;
+
+    use super::*;
+
+    #[test]
+    fn fail_if_gas_is_larger_than_membership_capacity() {
+        new_test_ext().execute_with(|| {
+            assert!(MembershipsGas::check_available_gas(
+                &SmallMember::get(),
+                &<() as frame_system::WeightInfo>::remark(14),
+            )
+            .is_none());
+            assert!(MembershipsGas::check_available_gas(
+                &MediumMember::get(),
+                &<() as frame_system::WeightInfo>::remark(27),
+            )
+            .is_none());
+            assert!(MembershipsGas::check_available_gas(
+                &LargeMember::get(),
+                &<() as frame_system::WeightInfo>::remark(40),
+            )
+            .is_none());
+        });
+    }
+
+    #[test]
+    fn it_works_returning_which_item_was_used_to_burn_gas() {
+        new_test_ext().execute_with(|| {
+            assert!(MembershipsGas::check_available_gas(
+                &SmallMember::get(),
+                &<() as frame_system::WeightInfo>::remark(13),
+            )
+            .is_some_and(|w| w.eq(&Weight::from_parts(1, 1))));
+            assert!(MembershipsGas::check_available_gas(
+                &MediumMember::get(),
+                &<() as frame_system::WeightInfo>::remark(26),
+            )
+            .is_some_and(|w| w.eq(&Weight::from_parts(1, 2))));
+            assert!(MembershipsGas::check_available_gas(
+                &LargeMember::get(),
+                &<() as frame_system::WeightInfo>::remark(39),
+            )
+            .is_some_and(|w| w.eq(&Weight::from_parts(1, 3))));
+        });
+    }
+}


### PR DESCRIPTION
This PR introduces the `NonFungibleGasBurner` with a base implementation, storing a gas tank into the attributes of a non-fungible item owned by the account being charged for executing the transaction.

> Note: Auto-implementation is not possible as there's no trait argument for `AccountId` in GasBurner, thus, it wouldn't be possible to set `AccountId` as a generic type parameter in the implementation block without a holding structure.