### PR TITLE
feat: [Pallet Pass] Configuration extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target/
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 .vscode
+.DS_Store

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ pallet-transaction-payment = { git = "https://github.com/virto-network/polkadot-
 pallet-utility = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-v1.13.0", default-features = false }
 
 [workspace]
+resolver = "2"
 members = [
   "pallets/gas-transaction-payment",
   "pallets/referenda-tracks",

--- a/pallets/pass/src/extension.rs
+++ b/pallets/pass/src/extension.rs
@@ -1,0 +1,101 @@
+use core::marker::PhantomData;
+
+use codec::{Decode, Encode};
+use frame_support::pallet_prelude::TransactionValidityError;
+use scale_info::{StaticTypeInfo, TypeInfo};
+use sp_runtime::traits::{DispatchInfoOf, SignedExtension};
+
+use crate::{Config, Pallet};
+
+#[derive(Encode, Decode)]
+pub struct ChargeTransactionToPassAccount<S, T, I = ()>(S, PhantomData<(T, I)>);
+
+impl<S: SignedExtension, T, I> ChargeTransactionToPassAccount<S, T, I> {
+    pub fn new(s: S) -> Self {
+        Self(s, PhantomData)
+    }
+}
+
+impl<S: Clone, T, I> Clone for ChargeTransactionToPassAccount<S, T, I> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), PhantomData)
+    }
+}
+
+impl<S: Eq, T, I> Eq for ChargeTransactionToPassAccount<S, T, I> {}
+impl<S: PartialEq, T, I> PartialEq for ChargeTransactionToPassAccount<S, T, I> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl<S: SignedExtension + StaticTypeInfo, T, I> TypeInfo
+    for ChargeTransactionToPassAccount<S, T, I>
+{
+    type Identity = S;
+    fn type_info() -> scale_info::Type {
+        S::type_info()
+    }
+}
+
+impl<S: SignedExtension + Encode, T, I> core::fmt::Debug
+    for ChargeTransactionToPassAccount<S, T, I>
+{
+    #[cfg(feature = "std")]
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        write!(f, "ChargeTransactionToPassAccount<{:?}>", self.0.encode())
+    }
+    #[cfg(not(feature = "std"))]
+    fn fmt(&self, _: &mut core::fmt::Formatter) -> core::fmt::Result {
+        Ok(())
+    }
+}
+
+impl<S, T, I> SignedExtension for ChargeTransactionToPassAccount<S, T, I>
+where
+    T: Config<I> + Send + Sync,
+    I: 'static + Send + Sync,
+    S: SignedExtension<AccountId = T::AccountId, Call = <T as frame_system::Config>::RuntimeCall>,
+{
+    const IDENTIFIER: &'static str = S::IDENTIFIER;
+    type AccountId = S::AccountId;
+    type Call = S::Call;
+    type AdditionalSigned = S::AdditionalSigned;
+    type Pre = S::Pre;
+
+    fn additional_signed(&self) -> Result<Self::AdditionalSigned, TransactionValidityError> {
+        self.0.additional_signed()
+    }
+
+    fn pre_dispatch(
+        self,
+        who: &Self::AccountId,
+        call: &Self::Call,
+        info: &DispatchInfoOf<Self::Call>,
+        len: usize,
+    ) -> Result<Self::Pre, TransactionValidityError> {
+        let who = Pallet::<T, I>::signer_from_session_key(&who).unwrap_or(who.clone());
+        self.0.pre_dispatch(&who, call, info, len)
+    }
+
+    fn validate(
+        &self,
+        who: &Self::AccountId,
+        call: &Self::Call,
+        info: &DispatchInfoOf<Self::Call>,
+        len: usize,
+    ) -> frame_support::pallet_prelude::TransactionValidity {
+        let who = Pallet::<T, I>::signer_from_session_key(&who).unwrap_or(who.clone());
+        self.0.validate(&who, call, info, len)
+    }
+
+    fn post_dispatch(
+        pre: Option<Self::Pre>,
+        info: &DispatchInfoOf<Self::Call>,
+        post_info: &sp_runtime::traits::PostDispatchInfoOf<Self::Call>,
+        len: usize,
+        result: &sp_runtime::DispatchResult,
+    ) -> Result<(), frame_support::pallet_prelude::TransactionValidityError> {
+        S::post_dispatch(pre, info, post_info, len, result)
+    }
+}

--- a/pallets/pass/src/extension.rs
+++ b/pallets/pass/src/extension.rs
@@ -74,7 +74,7 @@ where
         info: &DispatchInfoOf<Self::Call>,
         len: usize,
     ) -> Result<Self::Pre, TransactionValidityError> {
-        let who = Pallet::<T, I>::signer_from_session_key(&who).unwrap_or(who.clone());
+        let who = Pallet::<T, I>::signer_from_session_key(who).unwrap_or(who.clone());
         self.0.pre_dispatch(&who, call, info, len)
     }
 
@@ -85,7 +85,7 @@ where
         info: &DispatchInfoOf<Self::Call>,
         len: usize,
     ) -> frame_support::pallet_prelude::TransactionValidity {
-        let who = Pallet::<T, I>::signer_from_session_key(&who).unwrap_or(who.clone());
+        let who = Pallet::<T, I>::signer_from_session_key(who).unwrap_or(who.clone());
         self.0.validate(&who, call, info, len)
     }
 

--- a/pallets/pass/src/lib.rs
+++ b/pallets/pass/src/lib.rs
@@ -154,7 +154,7 @@ pub mod pallet {
 
         #[pallet::feeless_if(
             |_: &OriginFor<T>, device_id: &DeviceId, _: &CredentialOf<T, I>, _: &Option<BlockNumberFor<T>>| -> bool {
-                if let Some(account_id) = Pallet::<T, I>::account_id_for(credential.user_id()).ok() {
+                if let Ok(account_id) = Pallet::<T, I>::account_id_for(credential.user_id()) {
                     Pallet::<T, I>::account_exists(&account_id)
                 } else {
                     false
@@ -292,7 +292,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
     }
 
     pub(crate) fn signer_from_session_key(who: &T::AccountId) -> Option<T::AccountId> {
-        let (account_id, until) = Sessions::<T, I>::get(&who)?;
+        let (account_id, until) = Sessions::<T, I>::get(who)?;
         if frame_system::Pallet::<T>::block_number() <= until {
             Some(account_id)
         } else {

--- a/pallets/pass/src/lib.rs
+++ b/pallets/pass/src/lib.rs
@@ -163,7 +163,7 @@ pub mod pallet {
                         let device = Devices::<T, I>::get(&account_id, device_id)
                             .ok_or::<DispatchError>(Error::<T, I>::DeviceNotFound.into())?;
                         device
-                            .verify_user(&credential)
+                            .verify_user(credential)
                             .ok_or(Error::<T, I>::CredentialInvalid.into())
                     })
                     .is_ok()


### PR DESCRIPTION
This Pull Request implements two complementary extensions, necessary to make `pallet-pass` function correctly.

1. A `SignedExtension` that helps charging the actual `AccountId` for the pass user.
2. A decoration on the `authenticate` call to make it be free if the authentication attempt is valid (i.e. the device resolves to an `AccountId` and such account exists).
  This is because authentication should be a free service (I mean, how would you authenticate on a system if you can't pay fees otherwise?)