### PR TITLE
fix: [Traits for Authn] `UserAuthenticator` MUST verify credentials, not just let them validate themselves

### DIFF
--- a/pallets/pass/src/tests.rs
+++ b/pallets/pass/src/tests.rs
@@ -225,6 +225,91 @@ mod authenticate {
     }
 
     #[test]
+    fn fail_if_attested_with_credentials_from_a_different_device() {
+        new_test_ext().execute_with(|| {
+            assert_ok!(Balances::mint_into(&SIGNER, 2));
+
+            assert_ok!(Pass::register(
+                RuntimeOrigin::signed(SIGNER),
+                AccountNameA::get(),
+                PassDeviceAttestation::AuthenticatorB(authenticator_b::DeviceAttestation {
+                    device_id: THE_DEVICE,
+                    challenge: AuthenticatorB::generate(&THE_DEVICE),
+                }),
+            ));
+            assert_ok!(Pass::authenticate(
+                RuntimeOrigin::signed(SIGNER),
+                THE_DEVICE,
+                PassCredential::AuthenticatorB(authenticator_b::Credential {
+                    user_id: AccountNameA::get(),
+                    device_id: THE_DEVICE,
+                    challenge: AuthenticatorB::generate(&THE_DEVICE),
+                }),
+                None,
+            ));
+            assert_ok!(Pass::add_device(
+                RuntimeOrigin::signed(SIGNER),
+                PassDeviceAttestation::AuthenticatorB(authenticator_b::DeviceAttestation {
+                    device_id: OTHER_DEVICE,
+                    challenge: AuthenticatorB::generate(&OTHER_DEVICE),
+                }),
+            ));
+
+            assert_noop!(
+                Pass::authenticate(
+                    RuntimeOrigin::signed(OTHER),
+                    THE_DEVICE,
+                    PassCredential::AuthenticatorB(authenticator_b::Credential {
+                        user_id: AccountNameA::get(),
+                        device_id: OTHER_DEVICE,
+                        challenge: AuthenticatorB::generate(&OTHER_DEVICE),
+                    }),
+                    Some(DURATION),
+                ),
+                Error::<Test>::CredentialInvalid
+            );
+        });
+    }
+
+    #[test]
+    fn fail_if_attested_with_credentials_from_a_different_user_device() {
+        new_test_ext().execute_with(|| {
+            assert_ok!(Balances::mint_into(&SIGNER, 2));
+
+            assert_ok!(Pass::register(
+                RuntimeOrigin::signed(SIGNER),
+                AccountNameA::get(),
+                PassDeviceAttestation::AuthenticatorB(authenticator_b::DeviceAttestation {
+                    device_id: THE_DEVICE,
+                    challenge: AuthenticatorB::generate(&THE_DEVICE),
+                }),
+            ));
+            assert_ok!(Pass::register(
+                RuntimeOrigin::signed(SIGNER),
+                AccountNameB::get(),
+                PassDeviceAttestation::AuthenticatorB(authenticator_b::DeviceAttestation {
+                    device_id: OTHER_DEVICE,
+                    challenge: AuthenticatorB::generate(&OTHER_DEVICE),
+                }),
+            ));
+
+            assert_noop!(
+                Pass::authenticate(
+                    RuntimeOrigin::signed(OTHER),
+                    THE_DEVICE,
+                    PassCredential::AuthenticatorB(authenticator_b::Credential {
+                        user_id: AccountNameA::get(),
+                        device_id: OTHER_DEVICE,
+                        challenge: AuthenticatorB::generate(&OTHER_DEVICE),
+                    }),
+                    Some(DURATION),
+                ),
+                Error::<Test>::CredentialInvalid
+            );
+        });
+    }
+
+    #[test]
     fn it_works() {
         prepare(AccountNameA::get()).execute_with(|| {
             let block_number = System::block_number();

--- a/pallets/pass/src/tests.rs
+++ b/pallets/pass/src/tests.rs
@@ -212,11 +212,10 @@ mod authenticate {
                 Pass::authenticate(
                     RuntimeOrigin::signed(OTHER),
                     THE_DEVICE,
-                    PassCredential::AuthenticatorB(authenticator_b::Credential {
-                        user_id: AccountNameA::get(),
-                        device_id: THE_DEVICE,
-                        challenge: AuthenticatorB::generate(&OTHER_DEVICE),
-                    }),
+                    PassCredential::AuthenticatorB(authenticator_b::Credential::new(
+                        AccountNameA::get(),
+                        AuthenticatorB::generate(&OTHER_DEVICE)
+                    )),
                     Some(DURATION),
                 ),
                 Error::<Test>::CredentialInvalid
@@ -240,11 +239,13 @@ mod authenticate {
             assert_ok!(Pass::authenticate(
                 RuntimeOrigin::signed(SIGNER),
                 THE_DEVICE,
-                PassCredential::AuthenticatorB(authenticator_b::Credential {
-                    user_id: AccountNameA::get(),
-                    device_id: THE_DEVICE,
-                    challenge: AuthenticatorB::generate(&THE_DEVICE),
-                }),
+                PassCredential::AuthenticatorB(
+                    authenticator_b::Credential::new(
+                        AccountNameA::get(),
+                        AuthenticatorB::generate(&AccountNameA::get()),
+                    )
+                    .sign(&THE_DEVICE)
+                ),
                 None,
             ));
             assert_ok!(Pass::add_device(
@@ -259,11 +260,13 @@ mod authenticate {
                 Pass::authenticate(
                     RuntimeOrigin::signed(OTHER),
                     THE_DEVICE,
-                    PassCredential::AuthenticatorB(authenticator_b::Credential {
-                        user_id: AccountNameA::get(),
-                        device_id: OTHER_DEVICE,
-                        challenge: AuthenticatorB::generate(&OTHER_DEVICE),
-                    }),
+                    PassCredential::AuthenticatorB(
+                        authenticator_b::Credential::new(
+                            AccountNameA::get(),
+                            AuthenticatorB::generate(&AccountNameA::get())
+                        )
+                        .sign(&OTHER_DEVICE)
+                    ),
                     Some(DURATION),
                 ),
                 Error::<Test>::CredentialInvalid
@@ -297,11 +300,13 @@ mod authenticate {
                 Pass::authenticate(
                     RuntimeOrigin::signed(OTHER),
                     THE_DEVICE,
-                    PassCredential::AuthenticatorB(authenticator_b::Credential {
-                        user_id: AccountNameA::get(),
-                        device_id: OTHER_DEVICE,
-                        challenge: AuthenticatorB::generate(&OTHER_DEVICE),
-                    }),
+                    PassCredential::AuthenticatorB(
+                        authenticator_b::Credential::new(
+                            AccountNameA::get(),
+                            AuthenticatorB::generate(&AccountNameA::get()),
+                        )
+                        .sign(&OTHER_DEVICE)
+                    ),
                     Some(DURATION),
                 ),
                 Error::<Test>::CredentialInvalid

--- a/traits/authn/proc/src/lib.rs
+++ b/traits/authn/proc/src/lib.rs
@@ -161,7 +161,7 @@ pub fn composite_authenticator(input: TokenStream) -> TokenStream {
         }
     });
 
-    let match_credentials = authenticators.clone().into_iter().map(|(id, _)| {
+    let match_verify_user = authenticators.clone().into_iter().map(|(id, _)| {
         quote! {
             (
                 #device::#id(device),
@@ -169,6 +169,16 @@ pub fn composite_authenticator(input: TokenStream) -> TokenStream {
             ) => device.verify_user(credential)
         }
     });
+
+    let match_verify_credential = authenticators.clone().into_iter().map(|(id, _)| {
+        quote! {
+            (
+                #device::#id(device),
+                #credential::#id(credential),
+            ) => device.verify_credential(credential)
+        }
+    });
+
     let match_user_id = authenticators.clone().into_iter().map(|(id, _)| {
         quote! {
             #credential::#id(credential) => credential.user_id()
@@ -252,7 +262,14 @@ pub fn composite_authenticator(input: TokenStream) -> TokenStream {
 
             fn verify_user(&self, credential: &Self::Credential) -> Option<()> {
                 match (self, credential) {
-                    #(#match_credentials),*,
+                    #(#match_verify_user),*,
+                    _ => None,
+                }
+            }
+
+            fn verify_credential(&self, credential: &Self::Credential) -> Option<()> {
+                match (self, credential) {
+                    #(#match_verify_credential),*,
                     _ => None,
                 }
             }

--- a/traits/authn/src/lib.rs
+++ b/traits/authn/src/lib.rs
@@ -89,8 +89,11 @@ pub trait UserAuthenticator: FullCodec + MaxEncodedLen + TypeInfo {
             .then_some(())?;
         let (cx, challenge) = credential.used_challenge();
         Self::Challenger::check_challenge(&cx, &challenge)?;
-        credential.is_valid().then_some(())
+        credential.is_valid().then_some(())?;
+        self.verify_credential(credential)
     }
+
+    fn verify_credential(&self, credential: &Self::Credential) -> Option<()>;
 
     fn device_id(&self) -> &DeviceId;
 }

--- a/traits/authn/src/util.rs
+++ b/traits/authn/src/util.rs
@@ -38,7 +38,7 @@ where
     }
 }
 
-trait VerifyCredential<Cred> {
+pub trait VerifyCredential<Cred> {
     fn verify(&self, credential: &Cred) -> Option<()>;
 }
 

--- a/traits/authn/src/util.rs
+++ b/traits/authn/src/util.rs
@@ -38,6 +38,10 @@ where
     }
 }
 
+trait VerifyCredential<Cred> {
+    fn verify(&self, credential: &Cred) -> Option<()>;
+}
+
 /// Convenient auto-implemtator of the UserAuthenticator trait
 #[derive(Encode, Decode, TypeInfo)]
 #[scale_info(skip_type_params(A, Ch, Cred))]
@@ -51,7 +55,7 @@ impl<T, A, Ch, Cred> Dev<T, A, Ch, Cred> {
 
 impl<T, A, Ch, Cred> UserAuthenticator for Dev<T, A, Ch, Cred>
 where
-    T: AsRef<DeviceId> + FullCodec + MaxEncodedLen + TypeInfo + 'static,
+    T: VerifyCredential<Cred> + AsRef<DeviceId> + FullCodec + MaxEncodedLen + TypeInfo + 'static,
     A: Get<AuthorityId> + 'static,
     Ch: Challenger + 'static,
     Cred: UserChallengeResponse<Ch::Context> + 'static,
@@ -62,6 +66,10 @@ where
 
     fn device_id(&self) -> &DeviceId {
         self.0.as_ref()
+    }
+
+    fn verify_credential(&self, credential: &Self::Credential) -> Option<()> {
+        self.0.verify(credential)
     }
 }
 


### PR DESCRIPTION
There was a finding where, if a `credential` is valid, the authentication passes as long as the challenge can be validated by a `device`-`credential` pair.

Since `credential`s validate themselves, an instance of the `UserAuthenticator` (a.k.a. a `device`) has no way to know whether that `credential` is in some way bound to the `device` Ii.e. a way to know whether a `credential` was issued by the `device`, or more specifically, whether it was _signed_ by it).

This Pull Request resolves such issue, enforcing credentials to be verified by the device.