### PR TITLE
feat(fc-pallet-pass): more secure account derivation

### DIFF
--- a/traits/authn/src/lib.rs
+++ b/traits/authn/src/lib.rs
@@ -45,7 +45,8 @@ type CxOf<C> = <C as Challenger>::Context;
 
 pub type DeviceId = [u8; 32];
 pub type AuthorityId = [u8; 32];
-pub type HashedUserId = [u8; 32];
+pub const HASHED_USER_ID_LEN: usize = 32;
+pub type HashedUserId = [u8; HASHED_USER_ID_LEN];
 
 /// Given some context it deterministically generates a "challenge" used by authenticators
 pub trait Challenger {


### PR DESCRIPTION
This PR implements a new logic to calculate the `AccountId` for a Pass account, that uses a rehash for the already hashed user Id. This mitigates the feasibility to easily determine an accountId by merely using a brute-force method (or anything more sophisticated, like a rainbow hash).3