### PR TITLE
chore(cargo): bump to `stable2409-6`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -579,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -1105,7 +1105,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -1152,8 +1152,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+version = "38.2.0"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -1193,8 +1193,8 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural"
-version = "30.0.3"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+version = "30.0.6"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -1214,7 +1214,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1226,7 +1226,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1236,7 +1236,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "cfg-if",
  "docify",
@@ -1371,9 +1371,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1945,7 +1945,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-assets"
 version = "40.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1961,7 +1961,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1974,7 +1974,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1996,8 +1996,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-balances"
-version = "39.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+version = "39.0.1"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -2012,7 +2012,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts"
 version = "32.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -2029,7 +2029,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2045,7 +2045,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -2058,13 +2058,12 @@ dependencies = [
  "sp-arithmetic",
  "sp-io",
  "sp-runtime",
- "sp-std",
 ]
 
 [[package]]
 name = "pallet-scheduler"
 version = "39.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -2081,7 +2080,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2102,7 +2101,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "37.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -2120,8 +2119,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+version = "38.0.2"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2136,7 +2135,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2847,7 +2846,7 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 [[package]]
 name = "sp-api"
 version = "34.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "docify",
  "hash-db",
@@ -2869,7 +2868,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "Inflector",
  "blake2",
@@ -2883,7 +2882,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -2895,7 +2894,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -2909,7 +2908,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.40.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -2927,7 +2926,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.40.1"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -2938,7 +2937,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "34.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "array-bytes",
  "bitflags 1.3.2",
@@ -2984,7 +2983,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -2997,7 +2996,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
@@ -3007,7 +3006,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3017,7 +3016,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.29.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -3027,7 +3026,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.15.1"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -3039,7 +3038,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "34.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -3052,7 +3051,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "bytes",
  "docify",
@@ -3078,7 +3077,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.40.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "parity-scale-codec",
  "parking_lot",
@@ -3089,7 +3088,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.7.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -3099,7 +3098,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -3108,8 +3107,8 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "39.0.1"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+version = "39.0.5"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "docify",
  "either",
@@ -3135,7 +3134,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "28.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -3154,7 +3153,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "Inflector",
  "expander",
@@ -3167,7 +3166,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "36.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -3181,7 +3180,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "36.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -3194,7 +3193,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.43.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "hash-db",
  "log",
@@ -3214,12 +3213,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 
 [[package]]
 name = "sp-storage"
 version = "21.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -3231,7 +3230,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "34.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -3243,7 +3242,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.0.1"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -3254,7 +3253,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "37.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "ahash",
  "hash-db",
@@ -3277,7 +3276,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "37.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -3294,7 +3293,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "14.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -3305,7 +3304,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -3316,7 +3315,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -3361,7 +3360,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409#d13cf291bef64b5ab713ed864df18ce763a799fc"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -888,6 +888,7 @@ dependencies = [
  "frame-system",
  "mock-helpers",
  "pallet-assets",
+ "pallet-assets-holder",
  "pallet-balances",
  "pallet-nfts",
  "pallet-preimage",
@@ -1106,7 +1107,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -1154,7 +1155,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "38.2.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -1195,7 +1196,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "30.0.6"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -1215,7 +1216,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1227,7 +1228,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1237,7 +1238,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "cfg-if",
  "docify",
@@ -1946,7 +1947,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-assets"
 version = "40.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1962,7 +1963,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-holder"
 version = "0.1.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1977,7 +1978,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1990,7 +1991,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2013,7 +2014,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "39.0.1"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -2028,7 +2029,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts"
 version = "32.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -2045,7 +2046,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2061,7 +2062,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -2079,7 +2080,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "39.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -2096,7 +2097,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2117,7 +2118,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "37.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -2136,7 +2137,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "38.0.2"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2151,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2862,7 +2863,7 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 [[package]]
 name = "sp-api"
 version = "34.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "docify",
  "hash-db",
@@ -2884,7 +2885,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "Inflector",
  "blake2",
@@ -2898,7 +2899,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -2910,7 +2911,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -2924,7 +2925,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.40.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -2942,7 +2943,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.40.1"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -2953,7 +2954,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "34.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "array-bytes",
  "bitflags 1.3.2",
@@ -2999,7 +3000,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -3012,7 +3013,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
@@ -3022,7 +3023,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3032,7 +3033,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.29.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -3042,7 +3043,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.15.1"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -3054,7 +3055,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "34.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -3067,7 +3068,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "bytes",
  "docify",
@@ -3093,7 +3094,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.40.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "parity-scale-codec",
  "parking_lot",
@@ -3104,7 +3105,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.7.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -3114,7 +3115,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -3124,7 +3125,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "39.0.5"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "docify",
  "either",
@@ -3150,7 +3151,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "28.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -3169,7 +3170,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "Inflector",
  "expander",
@@ -3182,7 +3183,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "36.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -3196,7 +3197,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "36.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -3209,7 +3210,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.43.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "hash-db",
  "log",
@@ -3229,12 +3230,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 
 [[package]]
 name = "sp-storage"
 version = "21.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -3246,7 +3247,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "34.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -3258,7 +3259,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.0.1"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -3269,7 +3270,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "37.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "ahash",
  "hash-db",
@@ -3292,7 +3293,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "37.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -3309,7 +3310,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "14.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -3320,7 +3321,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -3331,7 +3332,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -3376,7 +3377,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#5bb9f014ef3c205877c8c6570f0948a1defd739b"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,6 +931,7 @@ dependencies = [
  "frame-system",
  "log",
  "pallet-assets",
+ "pallet-assets-holder",
  "pallet-balances",
  "pallet-preimage",
  "pallet-scheduler",
@@ -1105,7 +1106,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -1153,7 +1154,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "38.2.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -1194,7 +1195,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "30.0.6"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -1214,7 +1215,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate",
@@ -1226,7 +1227,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1236,7 +1237,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "cfg-if",
  "docify",
@@ -1945,7 +1946,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-assets"
 version = "40.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1959,9 +1960,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-assets-holder"
+version = "0.1.0"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-assets",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pallet-authorship"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1974,7 +1990,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -1997,7 +2013,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "39.0.1"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -2012,7 +2028,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts"
 version = "32.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -2029,7 +2045,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2045,7 +2061,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -2063,7 +2079,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "39.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -2080,7 +2096,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2101,7 +2117,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "37.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -2120,7 +2136,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "38.0.2"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -2135,7 +2151,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2846,7 +2862,7 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 [[package]]
 name = "sp-api"
 version = "34.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "docify",
  "hash-db",
@@ -2868,7 +2884,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "Inflector",
  "blake2",
@@ -2882,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -2894,7 +2910,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -2908,7 +2924,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.40.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -2926,7 +2942,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.40.1"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -2937,7 +2953,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "34.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "array-bytes",
  "bitflags 1.3.2",
@@ -2983,7 +2999,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -2996,7 +3012,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
@@ -3006,7 +3022,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3016,7 +3032,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.29.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -3026,7 +3042,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.15.1"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -3038,7 +3054,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "34.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -3051,7 +3067,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "38.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "bytes",
  "docify",
@@ -3077,7 +3093,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.40.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "parity-scale-codec",
  "parking_lot",
@@ -3088,7 +3104,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.7.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -3098,7 +3114,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -3108,7 +3124,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "39.0.5"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "docify",
  "either",
@@ -3134,7 +3150,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "28.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -3153,7 +3169,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "Inflector",
  "expander",
@@ -3166,7 +3182,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "36.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -3180,7 +3196,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "36.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -3193,7 +3209,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.43.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "hash-db",
  "log",
@@ -3213,12 +3229,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 
 [[package]]
 name = "sp-storage"
 version = "21.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -3230,7 +3246,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "34.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -3242,7 +3258,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.0.1"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -3253,7 +3269,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "37.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "ahash",
  "hash-db",
@@ -3276,7 +3292,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "37.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -3293,7 +3309,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "14.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -3304,7 +3320,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.1"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -3315,7 +3331,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.0.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -3360,7 +3376,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#ac9203f83b1fb635e0ae14ac9d648c3906bb4ba8"
+source = "git+https://github.com/virto-network/polkadot-sdk?branch=release-virto-stable2409-6#dea8098d4da8f32971db919f4222575268cfeb76"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,28 +31,28 @@ fc-traits-tracks = { path = "./traits/tracks", default-features = false }
 fc-pallet-listings = { path = "./pallets/listings", default-features = false }
 fc-pallet-payments = { path = "./pallets/payments", default-features = false }
 
-frame-benchmarking = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409", default-features = false }
-frame-support = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409", default-features = false }
-frame-system = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409", default-features = false }
+frame-benchmarking = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409-6", default-features = false }
+frame-support = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409-6", default-features = false }
+frame-system = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409-6", default-features = false }
 
 mock-helpers = { path = "./mock-helpers", default-features = false }
 
-sp-core = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409", default-features = false }
-sp-io = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409", default-features = false }
-sp-keystore = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409", default-features = false }
-sp-runtime = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409", default-features = false }
-sp-std = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409", default-features = false }
+sp-core = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409-6", default-features = false }
+sp-io = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409-6", default-features = false }
+sp-keystore = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409-6", default-features = false }
+sp-runtime = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409-6", default-features = false }
+sp-std = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409-6", default-features = false }
 
-pallet-assets = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409", default-features = false }
-pallet-babe = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409", default-features = false }
-pallet-balances = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409", default-features = false }
-pallet-nfts = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409", default-features = false }
-pallet-preimage = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409", default-features = false }
-pallet-referenda = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409", default-features = false }
-pallet-scheduler = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409", default-features = false }
-pallet-timestamp = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409", default-features = false }
-pallet-transaction-payment = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409", default-features = false }
-pallet-utility = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409", default-features = false }
+pallet-assets = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409-6", default-features = false }
+pallet-babe = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409-6", default-features = false }
+pallet-balances = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409-6", default-features = false }
+pallet-nfts = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409-6", default-features = false }
+pallet-preimage = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409-6", default-features = false }
+pallet-referenda = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409-6", default-features = false }
+pallet-scheduler = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409-6", default-features = false }
+pallet-timestamp = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409-6", default-features = false }
+pallet-transaction-payment = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409-6", default-features = false }
+pallet-utility = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409-6", default-features = false }
 
 [workspace]
 resolver = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ sp-runtime = { git = "https://github.com/virto-network/polkadot-sdk", branch = "
 sp-std = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409-6", default-features = false }
 
 pallet-assets = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409-6", default-features = false }
+pallet-assets-holder = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409-6", default-features = false }
 pallet-babe = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409-6", default-features = false }
 pallet-balances = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409-6", default-features = false }
 pallet-nfts = { git = "https://github.com/virto-network/polkadot-sdk", branch = "release-virto-stable2409-6", default-features = false }

--- a/pallets/orders/Cargo.toml
+++ b/pallets/orders/Cargo.toml
@@ -27,6 +27,7 @@ fc-pallet-listings.workspace = true
 fc-pallet-payments.workspace = true
 mock-helpers = { workspace = true, features = ["pallet-assets", "pallet-balances", "fc-pallet-listings"] }
 pallet-assets.workspace = true
+pallet-assets-holder.workspace = true
 pallet-balances.workspace = true
 pallet-nfts.workspace = true
 pallet-preimage.workspace = true
@@ -48,6 +49,7 @@ runtime-benchmarks = [
   "pallet-preimage/runtime-benchmarks",
   "pallet-scheduler/runtime-benchmarks",
   "sp-runtime/runtime-benchmarks",
+  "pallet-assets-holder/runtime-benchmarks"
 ]
 
 std = [
@@ -69,6 +71,7 @@ std = [
   "sp-io/std",
   "sp-runtime/std",
   "sp-std/std",
+  "pallet-assets-holder/std"
 ]
 
 try-runtime = [
@@ -82,4 +85,5 @@ try-runtime = [
   "pallet-preimage/try-runtime",
   "pallet-scheduler/try-runtime",
   "sp-runtime/try-runtime",
+  "pallet-assets-holder/try-runtime"
 ]

--- a/pallets/orders/src/mock.rs
+++ b/pallets/orders/src/mock.rs
@@ -1,13 +1,15 @@
 //! Test environment for template pallet.
 
-use crate::{self as fc_pallet_orders, Config, InventoryIdOf};
+use crate::{self as fc_pallet_orders, Config};
 use codec::{Decode, Encode, MaxEncodedLen};
 use core::cell::Cell;
 
 #[cfg(feature = "runtime-benchmarks")]
-use fc_pallet_listings::InventoryId;
+use {
+    crate::types::{InventoryIdOf, MerchantIdOf},
+    fc_pallet_listings::InventoryId,
+};
 
-use crate::types::MerchantIdOf;
 use fc_pallet_listings::{InventoryIdFor, ItemIdOf, ItemPrice};
 use frame_support::{
     derive_impl,
@@ -60,6 +62,8 @@ mod runtime {
     pub type Balances = pallet_balances;
     #[runtime::pallet_index(11)]
     pub type Assets = pallet_assets;
+    #[runtime::pallet_index(12)]
+    pub type AssetsHolder = pallet_assets_holder;
     #[runtime::pallet_index(20)]
     pub type Listings = fc_pallet_listings;
     #[runtime::pallet_index(21)]
@@ -115,6 +119,12 @@ impl pallet_assets::Config for Test {
     type ForceOrigin = EnsureRoot<AccountId>;
     type CreateOrigin = EnsureSigned<AccountId>;
     type Freezer = ();
+    type Holder = AssetsHolder;
+}
+
+impl pallet_assets_holder::Config for Test {
+    type RuntimeHoldReason = RuntimeHoldReason;
+    type RuntimeEvent = RuntimeEvent;
 }
 
 pub type AccountIdBytes = [u8; 32];
@@ -266,7 +276,7 @@ impl fc_pallet_payments::Config for Test {
     type PalletsOrigin = OriginCaller;
     type RuntimeCall = RuntimeCall;
     type Assets = Assets;
-    type AssetsHold = Assets;
+    type AssetsHold = AssetsHolder;
     type FeeHandler = ();
     type SenderOrigin = EnsureSigned<AccountId>;
     type BeneficiaryOrigin = EnsureSigned<AccountId>;

--- a/pallets/orders/src/tests.rs
+++ b/pallets/orders/src/tests.rs
@@ -679,7 +679,7 @@ mod pay {
             // The balances hold (pun intended).
             let price = 15;
             assert_eq!(Assets::balance(ASSET_A, &BOB), bob_asset_b_balance - price);
-            assert_eq!(Assets::total_balance_on_hold(ASSET_A, &ALICE), price);
+            assert_eq!(AssetsHolder::total_balance_on_hold(ASSET_A, &ALICE), price);
 
             // Once BOB releases the payment (since CHARLIE received the payment), the item will be
             // unlocked.
@@ -690,7 +690,7 @@ mod pay {
             ));
             assert!(Listings::transferable(&inventory_id, &item_id));
             assert_eq!(Assets::balance(ASSET_A, &ALICE), alice_balance + price);
-            assert_eq!(Assets::total_balance_on_hold(ASSET_A, &ALICE), 0);
+            assert_eq!(AssetsHolder::total_balance_on_hold(ASSET_A, &ALICE), 0);
 
             // Since all the items have been delivered, the order is now completed
             assert!(matches!(

--- a/pallets/payments/Cargo.toml
+++ b/pallets/payments/Cargo.toml
@@ -26,6 +26,7 @@ log.workspace = true
 serde.workspace = true
 pallet-balances.workspace = true
 pallet-assets.workspace = true
+pallet-assets-holder.workspace = true
 sp-keystore.workspace = true
 pallet-preimage.workspace = true
 pallet-scheduler.workspace = true
@@ -41,6 +42,7 @@ runtime-benchmarks = [
 	"pallet-preimage/runtime-benchmarks",
 	"pallet-scheduler/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"pallet-assets-holder/runtime-benchmarks"
 ]
 std = [
 	"codec/std",
@@ -59,6 +61,7 @@ std = [
 	"sp-io/std",
 	"sp-keystore/std",
 	"sp-runtime/std",
+	"pallet-assets-holder/std"
 ]
 try-runtime = [
 	"frame-support/try-runtime",
@@ -68,4 +71,5 @@ try-runtime = [
 	"pallet-preimage/try-runtime",
 	"pallet-scheduler/try-runtime",
 	"sp-runtime/try-runtime",
+	"pallet-assets-holder/try-runtime"
 ]

--- a/pallets/payments/src/mock.rs
+++ b/pallets/payments/src/mock.rs
@@ -72,6 +72,9 @@ mod runtime {
     pub type Balances = pallet_balances;
     #[runtime::pallet_index(11)]
     pub type Assets = pallet_assets;
+    #[runtime::pallet_index(12)]
+    pub type AssetsHolder = pallet_assets_holder;
+
     #[runtime::pallet_index(20)]
     pub type Payments = pallet_payments;
 }
@@ -99,10 +102,15 @@ impl pallet_balances::Config for Test {
 #[derive_impl(pallet_assets::config_preludes::TestDefaultConfig as pallet_assets::DefaultConfig)]
 impl pallet_assets::Config for Test {
     type Currency = Balances;
-    type CreateOrigin = AsEnsureOriginWithArg<frame_system::EnsureSigned<u64>>;
-    type ForceOrigin = frame_system::EnsureRoot<u64>;
+    type CreateOrigin = AsEnsureOriginWithArg<EnsureSigned<u64>>;
+    type ForceOrigin = EnsureRoot<u64>;
     type Freezer = ();
+    type Holder = AssetsHolder;
+}
+
+impl pallet_assets_holder::Config for Test {
     type RuntimeHoldReason = RuntimeHoldReason;
+    type RuntimeEvent = RuntimeEvent;
 }
 
 impl pallet_preimage::Config for Test {
@@ -243,7 +251,7 @@ impl Config for Test {
     type PalletsOrigin = OriginCaller;
     type RuntimeCall = RuntimeCall;
     type Assets = Assets;
-    type AssetsHold = Assets;
+    type AssetsHold = AssetsHolder;
     type FeeHandler = MockFeeHandler;
     type SenderOrigin = EnsureSigned<AccountId>;
     type BeneficiaryOrigin = EnsureSigned<AccountId>;

--- a/pallets/payments/src/tests.rs
+++ b/pallets/payments/src/tests.rs
@@ -54,7 +54,7 @@ fn build_payment(assert_payment_creation: bool) -> Fees<Test> {
         );
 
         assert_eq!(
-            <Assets as fungibles::InspectHold<_>>::balance_on_hold(
+            <AssetsHolder as fungibles::InspectHold<_>>::balance_on_hold(
                 ASSET_ID,
                 reason,
                 &PAYMENT_BENEFICIARY
@@ -62,7 +62,7 @@ fn build_payment(assert_payment_creation: bool) -> Fees<Test> {
             PAYMENT_AMOUNT
         );
         assert_eq!(
-            <Assets as fungibles::InspectHold<_>>::balance_on_hold(
+            <AssetsHolder as fungibles::InspectHold<_>>::balance_on_hold(
                 ASSET_ID,
                 reason,
                 &SENDER_ACCOUNT

--- a/traits/tracks/src/lib.rs
+++ b/traits/tracks/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use core::fmt::Debug;
 use frame_support::dispatch::DispatchResult;
 use pallet_referenda::{TrackInfo, TracksInfo};
 
@@ -7,8 +8,8 @@ pub use crate::Mutate as MutateTracks;
 
 pub trait Mutate<Balance, Moment>: TracksInfo<Balance, Moment>
 where
-    Balance: Clone + 'static,
-    Moment: Clone + 'static,
+    Balance: Clone + Debug + Eq + 'static,
+    Moment: Clone + Debug + Eq + 'static,
 {
     /// Inserts a new track into the tracks storage.
     fn insert(


### PR DESCRIPTION
This PR upgrades `frame-contrib` to the latest patch of the Polkadot SDK `stable2904`, with some minor custom backports

- https://github.com/paritytech/polkadot-sdk/pull/2072
- https://github.com/paritytech/polkadot-sdk/pull/7671
- https://github.com/paritytech/polkadot-sdk/pull/4530