### PR TITLE
fix(fc-pallet-pass): prevent reusing credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,13 +71,13 @@ version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
-  "anstyle",
-  "anstyle-parse",
-  "anstyle-query",
-  "anstyle-wincon",
-  "colorchoice",
-  "is_terminal_polyfill",
-  "utf8parse",
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
 ]
 
 [[package]]
@@ -92,7 +92,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
-  "utf8parse",
+ "utf8parse",
 ]
 
 [[package]]
@@ -101,7 +101,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
-  "windows-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -110,9 +110,9 @@ version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
-  "anstyle",
-  "once_cell",
-  "windows-sys",
+ "anstyle",
+ "once_cell",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1099,8 +1099,8 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
-  "log",
-  "regex",
+ "log",
+ "regex",
 ]
 
 [[package]]
@@ -1109,11 +1109,11 @@ version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
 dependencies = [
-  "anstream",
-  "anstyle",
-  "env_filter",
-  "jiff",
-  "log",
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -1229,7 +1229,7 @@ dependencies = [
 name = "fc-pallet-pass"
 version = "1.0.0"
 dependencies = [
-  "env_logger",
+ "env_logger",
  "fc-traits-authn",
  "frame-benchmarking",
  "frame-support",
@@ -2060,11 +2060,11 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02000660d30638906021176af16b17498bd0d12813dbfe7b276d8bc7f3c0806"
 dependencies = [
-  "jiff-static",
-  "log",
-  "portable-atomic",
-  "portable-atomic-util",
-  "serde",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
 ]
 
 [[package]]
@@ -2073,9 +2073,9 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c30758ddd7188629c6713fc45d1188af4f44c90582311d0c8d8c9907f60c48"
 dependencies = [
-  "proc-macro2",
-  "quote",
-  "syn 2.0.101",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2871,7 +2871,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
 dependencies = [
-  "portable-atomic",
+ "portable-atomic",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+  "anstyle",
+  "anstyle-parse",
+  "anstyle-query",
+  "anstyle-wincon",
+  "colorchoice",
+  "is_terminal_polyfill",
+  "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+  "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+  "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+  "anstyle",
+  "once_cell",
+  "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,6 +676,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
 name = "common-path"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +1094,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+  "log",
+  "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+  "anstream",
+  "anstyle",
+  "env_filter",
+  "jiff",
+  "log",
+]
+
+[[package]]
 name = "environmental"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1150,6 +1229,7 @@ dependencies = [
 name = "fc-pallet-pass"
 version = "1.0.0"
 dependencies = [
+  "env_logger",
  "fc-traits-authn",
  "frame-benchmarking",
  "frame-support",
@@ -1936,6 +2016,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1967,6 +2053,30 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02000660d30638906021176af16b17498bd0d12813dbfe7b276d8bc7f3c0806"
+dependencies = [
+  "jiff-static",
+  "log",
+  "portable-atomic",
+  "portable-atomic-util",
+  "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c30758ddd7188629c6713fc45d1188af4f44c90582311d0c8d8c9907f60c48"
+dependencies = [
+  "proc-macro2",
+  "quote",
+  "syn 2.0.101",
+]
 
 [[package]]
 name = "k256"
@@ -2747,6 +2857,21 @@ checksum = "48c16669ddc7433e34c1007d31080b80901e3e8e523cb9d4b441c3910cf9294b"
 dependencies = [
  "polkavm-derive-impl",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+  "portable-atomic",
 ]
 
 [[package]]
@@ -4294,6 +4419,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"

--- a/pallets/pass/Cargo.toml
+++ b/pallets/pass/Cargo.toml
@@ -22,6 +22,7 @@ sp-core.workspace = true
 sp-runtime.workspace = true
 
 [dev-dependencies]
+env_logger = "0.11.8"
 pallet-babe.workspace = true
 pallet-balances.workspace = true
 pallet-scheduler.workspace = true

--- a/pallets/pass/src/benchmarking.rs
+++ b/pallets/pass/src/benchmarking.rs
@@ -1,13 +1,45 @@
 use super::*;
-use crate::Pallet;
+use crate::{DeviceOf, Pallet};
+
 use frame_benchmarking::v2::*;
-use frame_support::traits::OriginTrait;
+use frame_support::{assert_ok, traits::OriginTrait};
+use frame_system::RawOrigin;
 use sp_runtime::traits::Hash;
 
 type RuntimeEventFor<T, I> = <T as Config<I>>::RuntimeEvent;
 
 fn assert_has_event<T: Config<I>, I: 'static>(generic_event: RuntimeEventFor<T, I>) {
     frame_system::Pallet::<T>::assert_has_event(generic_event.into());
+}
+
+fn prepare_register<T: Config<I>, I: 'static>(
+    hashed_user_id: HashedUserId,
+) -> Result<T::RuntimeOrigin, BenchmarkError> {
+    let origin = T::RegisterOrigin::try_successful_origin(&hashed_user_id)
+        .map_err(|_| DispatchError::BadOrigin)?;
+    let registrar_account_id = T::RegisterOrigin::ensure_origin(origin.clone(), &hashed_user_id)
+        .map_err(|_| DispatchError::BadOrigin)?;
+
+    T::RegistrarConsideration::ensure_successful(
+        &registrar_account_id,
+        Footprint::from_parts(1, HashedUserId::max_encoded_len()),
+    );
+
+    Ok(origin)
+}
+
+fn do_register<T: Config<I>, I: 'static>(
+    hashed_user_id: HashedUserId,
+    device_id: DeviceId,
+) -> Result<(), BenchmarkError> {
+    let origin = prepare_register::<T, I>(hashed_user_id)
+        .map_err(|_| BenchmarkError::Stop("Cannot prepare origin"))?;
+    Pallet::<T, I>::register(
+        origin,
+        hashed_user_id,
+        T::BenchmarkHelper::device_attestation(device_id, &[]),
+    )
+    .map_err(|_| BenchmarkError::Stop("Cannot register pass account"))
 }
 
 #[allow(dead_code)]
@@ -30,12 +62,13 @@ where
 )]
 mod benchmarks {
     use super::*;
-
     #[benchmark]
+
     pub fn register() -> Result<(), BenchmarkError> {
         // Setup code
-        let origin = T::BenchmarkHelper::register_origin();
         let user_id = hash::<T>(b"my-account");
+        let origin = prepare_register::<T, I>(user_id)?;
+
         let account_id = Pallet::<T, I>::address_for(user_id);
         let device_id = [0u8; 32];
 
@@ -43,11 +76,170 @@ mod benchmarks {
         _(
             origin.into_caller(),
             user_id,
-            T::BenchmarkHelper::device_attestation(device_id),
+            T::BenchmarkHelper::device_attestation(device_id, &[]),
         );
 
         // Verification code
-        assert_has_event::<T, I>(Event::Registered { who: account_id }.into());
+        assert_has_event::<T, I>(
+            Event::Registered {
+                who: account_id.clone(),
+            }
+            .into(),
+        );
+        assert_has_event::<T, I>(
+            Event::DeviceAdded {
+                who: account_id,
+                device_id,
+            }
+            .into(),
+        );
+
+        Ok(())
+    }
+
+    #[benchmark]
+    pub fn authenticate() -> Result<(), BenchmarkError> {
+        // Setup code
+        let user_id = hash::<T>(b"my-account");
+        let device_id = [0u8; 32];
+        do_register::<T, I>(user_id, device_id)?;
+
+        #[block]
+        {
+            assert_ok!(Pallet::<T, I>::authenticate(
+                &device_id,
+                &T::BenchmarkHelper::credential(user_id, &[]),
+                &[]
+            ));
+        }
+
+        Ok(())
+    }
+
+    #[benchmark]
+    pub fn add_device() -> Result<(), BenchmarkError> {
+        // Setup code
+        let user_id = hash::<T>(b"my-account");
+        let device_id = [0u8; 32];
+        do_register::<T, I>(user_id, device_id)?;
+
+        let address = Pallet::<T, I>::address_for(user_id);
+        let new_device_id = [1u8; 32];
+        T::DeviceConsideration::ensure_successful(
+            &address,
+            Footprint::from_parts(2, DeviceOf::<T, I>::max_encoded_len()),
+        );
+
+        #[extrinsic_call]
+        _(
+            RawOrigin::Signed(address.clone()),
+            T::BenchmarkHelper::device_attestation(new_device_id, &[]),
+        );
+
+        // Verification code
+        assert_has_event::<T, I>(
+            Event::DeviceAdded {
+                who: address,
+                device_id: new_device_id,
+            }
+            .into(),
+        );
+
+        Ok(())
+    }
+
+    #[benchmark]
+    pub fn remove_device() -> Result<(), BenchmarkError> {
+        // Setup code
+        let user_id = hash::<T>(b"my-account");
+        let device_id = [0u8; 32];
+        do_register::<T, I>(user_id, device_id)?;
+
+        let address = Pallet::<T, I>::address_for(user_id);
+        let new_device_id = [1u8; 32];
+        T::DeviceConsideration::ensure_successful(
+            &address,
+            Footprint::from_parts(2, DeviceOf::<T, I>::max_encoded_len()),
+        );
+
+        Pallet::<T, I>::add_device(
+            RawOrigin::Signed(address.clone()).into(),
+            T::BenchmarkHelper::device_attestation(new_device_id, &[]),
+        )?;
+
+        #[extrinsic_call]
+        _(RawOrigin::Signed(address.clone()), new_device_id);
+
+        // Verification code
+        assert_has_event::<T, I>(
+            Event::DeviceRemoved {
+                who: address,
+                device_id: new_device_id,
+            }
+            .into(),
+        );
+
+        Ok(())
+    }
+
+    #[benchmark]
+    pub fn add_session_key() -> Result<(), BenchmarkError> {
+        // Setup code
+        let user_id = hash::<T>(b"my-account");
+        let device_id = [0u8; 32];
+        do_register::<T, I>(user_id, device_id)?;
+
+        let address = Pallet::<T, I>::address_for(user_id);
+        let new_session_key: T::AccountId = account("session-key", 0, 0);
+        T::DeviceConsideration::ensure_successful(
+            &address,
+            Footprint::from_parts(2, T::AccountId::max_encoded_len()),
+        );
+
+        #[extrinsic_call]
+        _(
+            RawOrigin::Signed(address.clone()),
+            T::Lookup::unlookup(new_session_key.clone()),
+            None,
+        );
+
+        // Verification code
+        assert_has_event::<T, I>(
+            Event::SessionCreated {
+                session_key: new_session_key,
+                until: T::MaxSessionDuration::get(),
+            }
+            .into(),
+        );
+
+        Ok(())
+    }
+
+    #[benchmark]
+    pub fn remove_session_key() -> Result<(), BenchmarkError> {
+        // Setup code
+        let user_id = hash::<T>(b"my-account");
+        let device_id = [0u8; 32];
+        do_register::<T, I>(user_id, device_id)?;
+
+        let address = Pallet::<T, I>::address_for(user_id);
+        let session_key: T::AccountId = account("session-key", 0, 0);
+        T::DeviceConsideration::ensure_successful(
+            &address,
+            Footprint::from_parts(2, T::AccountId::max_encoded_len()),
+        );
+
+        Pallet::<T, I>::add_session_key(
+            RawOrigin::Signed(address.clone()).into(),
+            T::Lookup::unlookup(session_key.clone()),
+            None,
+        )?;
+
+        #[extrinsic_call]
+        _(RawOrigin::Root, session_key.clone());
+
+        // Verification code
+        assert_has_event::<T, I>(Event::SessionRemoved { session_key }.into());
 
         Ok(())
     }

--- a/pallets/pass/src/lib.rs
+++ b/pallets/pass/src/lib.rs
@@ -231,10 +231,10 @@ pub mod pallet {
                 RegistrarConsiderations<T, I>,
                 T::RegistrarConsideration,
                 HashedUserId,
-            >::increment(&registrar)?;
+            >::increment(registrar)?;
 
-            Self::create_account(&address)?;
-            Self::try_add_device(&address, attestation)
+            Self::create_account(address)?;
+            Self::try_add_device(address, attestation)
         }
 
         #[pallet::call_index(1)]
@@ -275,7 +275,7 @@ pub mod pallet {
                 SessionKeyConsiderations<T, I>,
                 T::SessionKeyConsideration,
                 T::AccountId,
-            >::increment(&address)?;
+            >::increment(address)?;
 
             // Let's try to remove an existing session that uses the same session key (if any). This is
             // so we ensure we decrease the provider counter correctly.
@@ -378,7 +378,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
             DeviceConsiderations<T, I>,
             T::DeviceConsideration,
             DeviceOf<T, I>,
-        >::increment(&address)?;
+        >::increment(address)?;
 
         Devices::<T, I>::insert(address, device_id, device);
 
@@ -401,13 +401,13 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
             DeviceConsiderations<T, I>,
             T::DeviceConsideration,
             DeviceOf<T, I>,
-        >::decrement(&address)?;
+        >::decrement(address)?;
 
         Devices::<T, I>::remove(address, id);
 
         Self::deposit_event(Event::<T, I>::DeviceRemoved {
             who: address.clone(),
-            device_id: id.clone(),
+            device_id: *id,
         });
 
         Ok(())
@@ -423,7 +423,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
                 SessionKeyConsiderations<T, I>,
                 T::SessionKeyConsideration,
                 T::AccountId,
-            >::decrement(&address)?;
+            >::decrement(address)?;
 
             SessionKeys::<T, I>::remove(session_key);
 

--- a/pallets/pass/src/lib.rs
+++ b/pallets/pass/src/lib.rs
@@ -5,6 +5,7 @@
 //! > TODO: Update with [spec](https://hackmd.io/@pandres95/pallet-pass) document once complete
 
 extern crate alloc;
+extern crate core;
 
 use core::fmt::Debug;
 use fc_traits_authn::{

--- a/pallets/pass/src/lib.rs
+++ b/pallets/pass/src/lib.rs
@@ -195,7 +195,6 @@ pub mod pallet {
         },
         SessionRemoved {
             session_key: T::AccountId,
-            until: BlockNumberFor<T>,
         },
     }
 
@@ -427,6 +426,10 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
             >::decrement(&address)?;
 
             SessionKeys::<T, I>::remove(session_key);
+
+            Self::deposit_event(Event::<T, I>::SessionRemoved {
+                session_key: session_key.clone(),
+            })
         }
 
         Ok(())

--- a/pallets/pass/src/mock.rs
+++ b/pallets/pass/src/mock.rs
@@ -205,17 +205,20 @@ impl pallet_pass::BenchmarkHelper<Test> for BenchmarkHelper {
         RuntimeOrigin::root()
     }
 
-    fn device_attestation(device_id: DeviceId) -> DeviceAttestationOf<Test, ()> {
+    fn device_attestation(
+        device_id: DeviceId,
+        xtc: &impl ExtrinsicContext,
+    ) -> DeviceAttestationOf<Test, ()> {
         PassDeviceAttestation::AuthenticatorAAuthenticator(authenticator_a::DeviceAttestation {
             device_id,
-            challenge: authenticator_a::Authenticator::generate(&()),
+            challenge: authenticator_a::Authenticator::generate(&(), xtc),
         })
     }
 
-    fn credential(user_id: HashedUserId) -> CredentialOf<Test, ()> {
+    fn credential(user_id: HashedUserId, xtc: &impl ExtrinsicContext) -> CredentialOf<Test, ()> {
         PassCredential::AuthenticatorAAuthenticator(authenticator_a::Credential {
             user_id,
-            challenge: authenticator_a::Authenticator::generate(&()),
+            challenge: authenticator_a::Authenticator::generate(&(), xtc),
         })
     }
 }

--- a/pallets/pass/src/mock.rs
+++ b/pallets/pass/src/mock.rs
@@ -188,38 +188,36 @@ impl Config for Test {
     type PalletId = PassPalletId;
     type MaxSessionDuration = ConstU64<10>;
     #[cfg(feature = "runtime-benchmarks")]
-    type BenchmarkHelper = BenchmarkHelper;
+    type BenchmarkHelper = benchmarks::BenchmarkHelper;
 }
 
 #[cfg(feature = "runtime-benchmarks")]
-use frame_system::pallet_prelude::OriginFor;
-#[cfg(feature = "runtime-benchmarks")]
-use pallet_pass::{CredentialOf, DeviceAttestationOf};
+mod benchmarks {
+    use super::*;
+    use pallet_pass::{CredentialOf, DeviceAttestationOf};
 
-#[cfg(feature = "runtime-benchmarks")]
-pub struct BenchmarkHelper;
+    pub struct BenchmarkHelper;
 
-#[cfg(feature = "runtime-benchmarks")]
-impl pallet_pass::BenchmarkHelper<Test> for BenchmarkHelper {
-    fn register_origin() -> OriginFor<Test> {
-        RuntimeOrigin::root()
-    }
+    impl pallet_pass::BenchmarkHelper<Test> for BenchmarkHelper {
+        fn device_attestation(
+            device_id: DeviceId,
+            xtc: &impl ExtrinsicContext,
+        ) -> DeviceAttestationOf<Test, ()> {
+            PassDeviceAttestation::AuthenticatorAAuthenticator(authenticator_a::DeviceAttestation {
+                device_id,
+                challenge: authenticator_a::Authenticator::generate(&(), xtc),
+            })
+        }
 
-    fn device_attestation(
-        device_id: DeviceId,
-        xtc: &impl ExtrinsicContext,
-    ) -> DeviceAttestationOf<Test, ()> {
-        PassDeviceAttestation::AuthenticatorAAuthenticator(authenticator_a::DeviceAttestation {
-            device_id,
-            challenge: authenticator_a::Authenticator::generate(&(), xtc),
-        })
-    }
-
-    fn credential(user_id: HashedUserId, xtc: &impl ExtrinsicContext) -> CredentialOf<Test, ()> {
-        PassCredential::AuthenticatorAAuthenticator(authenticator_a::Credential {
-            user_id,
-            challenge: authenticator_a::Authenticator::generate(&(), xtc),
-        })
+        fn credential(
+            user_id: HashedUserId,
+            xtc: &impl ExtrinsicContext,
+        ) -> CredentialOf<Test, ()> {
+            PassCredential::AuthenticatorAAuthenticator(authenticator_a::Credential {
+                user_id,
+                challenge: authenticator_a::Authenticator::generate(&(), xtc),
+            })
+        }
     }
 }
 

--- a/pallets/pass/src/mock.rs
+++ b/pallets/pass/src/mock.rs
@@ -122,7 +122,7 @@ parameter_types! {
 composite_authenticators! {
     pub Pass<AuthorityFromPalletId<PassPalletId>> {
         authenticator_a::Authenticator,
-        AuthenticatorB,
+        AuthenticatorB::<LastThreeBlocksChallenger>,
     };
 }
 

--- a/pallets/pass/src/mock/authenticators.rs
+++ b/pallets/pass/src/mock/authenticators.rs
@@ -1,6 +1,7 @@
 use super::*;
 use fc_traits_authn::{util::AuthorityFromPalletId, *};
 use frame_support::traits::Randomness;
+use frame_system::pallet_prelude::BlockNumberFor;
 use sp_core::Get;
 
 pub use authenticator_b::AuthenticatorB;
@@ -122,38 +123,59 @@ pub mod authenticator_a {
     }
 }
 
+pub struct LastThreeBlocksChallenger;
+impl Challenger for LastThreeBlocksChallenger {
+    type Context = BlockNumberFor<Test>;
+
+    fn check_challenge(cx: &Self::Context, challenge: &[u8]) -> Option<()> {
+        let block_number = System::block_number();
+        let range = block_number.saturating_sub(3)..=block_number;
+        (range.contains(cx) && challenge.eq(&Self::generate(cx))).then_some(())
+    }
+
+    fn generate(context: &Self::Context) -> Challenge {
+        let (hash, _) = RandomnessFromBlockNumber::random(&context.to_le_bytes());
+        hash.0
+    }
+}
+
 pub mod authenticator_b {
     use super::*;
     use codec::DecodeWithMemTracking;
+    use core::marker::PhantomData;
+    use frame_support::Parameter;
 
-    pub struct AuthenticatorB;
+    type CxOf<Ch> = <Ch as Challenger>::Context;
 
-    #[derive(
-        TypeInfo, DebugNoBound, EqNoBound, PartialEq, Clone, Encode, Decode, DecodeWithMemTracking,
-    )]
-    pub struct DeviceAttestation {
+    pub struct AuthenticatorB<C>(PhantomData<C>);
+
+    #[derive(TypeInfo, Debug, Eq, PartialEq, Clone, Encode, Decode, DecodeWithMemTracking)]
+    pub struct DeviceAttestation<Cx> {
         pub(crate) device_id: DeviceId,
+        pub(crate) context: Cx,
         pub(crate) challenge: Challenge,
     }
 
     #[derive(TypeInfo, Encode, Decode, DecodeWithMemTracking, MaxEncodedLen)]
-    pub struct Device {
+    #[scale_info(skip_type_params(C))]
+    pub struct Device<C> {
         pub(crate) device_id: DeviceId,
+        _data: PhantomData<C>,
     }
 
-    #[derive(
-        TypeInfo, DebugNoBound, EqNoBound, PartialEq, Clone, Encode, Decode, DecodeWithMemTracking,
-    )]
-    pub struct Credential {
+    #[derive(TypeInfo, Debug, Eq, PartialEq, Clone, Encode, Decode, DecodeWithMemTracking)]
+    pub struct Credential<Cx> {
         pub(crate) user_id: HashedUserId,
+        pub(crate) context: Cx,
         pub(crate) challenge: Challenge,
         pub(crate) signature: Option<[u8; 32]>,
     }
 
-    impl Credential {
-        pub fn new(user_id: HashedUserId, challenge: Challenge) -> Self {
+    impl<Cx> Credential<Cx> {
+        pub fn new(user_id: HashedUserId, context: Cx, challenge: Challenge) -> Self {
             Self {
                 user_id,
+                context,
                 challenge,
                 signature: None,
             }
@@ -172,32 +194,31 @@ pub mod authenticator_b {
         }
     }
 
-    impl Authenticator for AuthenticatorB {
+    impl<C: Challenger + 'static> Authenticator for AuthenticatorB<C>
+    where
+        CxOf<C>: Parameter + Send + Sync + Copy + 'static,
+    {
         type Authority = PassAuthorityId;
-        type Challenger = Self;
-        type DeviceAttestation = DeviceAttestation;
-        type Device = Device;
+        type Challenger = C;
+        type DeviceAttestation = DeviceAttestation<CxOf<C>>;
+        type Device = Device<C>;
 
         fn unpack_device(attestation: Self::DeviceAttestation) -> Self::Device {
             Device {
                 device_id: attestation.device_id,
+                _data: PhantomData,
             }
         }
     }
 
-    impl Challenger for AuthenticatorB {
-        type Context = DeviceId;
-
-        fn generate(context: &Self::Context) -> Challenge {
-            let (hash, _) = RandomnessFromBlockNumber::random(context);
-            hash.0
-        }
-    }
-
-    impl UserAuthenticator for Device {
+    impl<C> UserAuthenticator for Device<C>
+    where
+        C: Challenger + 'static,
+        CxOf<C>: Parameter + Send + Sync + Copy + 'static,
+    {
         type Authority = PassAuthorityId;
-        type Challenger = AuthenticatorB;
-        type Credential = Credential;
+        type Challenger = C;
+        type Credential = Credential<CxOf<C>>;
 
         fn verify_credential(&self, credential: &Self::Credential) -> Option<()> {
             credential.signature.and_then(|signature| {
@@ -212,13 +233,16 @@ pub mod authenticator_b {
         }
     }
 
-    impl DeviceChallengeResponse<DeviceId> for DeviceAttestation {
+    impl<Cx> DeviceChallengeResponse<Cx> for DeviceAttestation<Cx>
+    where
+        Cx: Parameter + Copy + 'static,
+    {
         fn is_valid(&self) -> bool {
             true
         }
 
-        fn used_challenge(&self) -> (DeviceId, Challenge) {
-            (self.device_id, self.challenge)
+        fn used_challenge(&self) -> (Cx, Challenge) {
+            (self.context, self.challenge)
         }
 
         fn authority(&self) -> AuthorityId {
@@ -230,13 +254,16 @@ pub mod authenticator_b {
         }
     }
 
-    impl UserChallengeResponse<DeviceId> for Credential {
+    impl<Cx> UserChallengeResponse<Cx> for Credential<Cx>
+    where
+        Cx: Parameter + Copy + 'static,
+    {
         fn is_valid(&self) -> bool {
             self.signature.is_some()
         }
 
-        fn used_challenge(&self) -> (DeviceId, Challenge) {
-            (self.user_id, self.challenge)
+        fn used_challenge(&self) -> (Cx, Challenge) {
+            (self.context, self.challenge)
         }
 
         fn authority(&self) -> AuthorityId {

--- a/pallets/pass/src/tests.rs
+++ b/pallets/pass/src/tests.rs
@@ -108,7 +108,7 @@ mod register {
                         context: System::block_number(),
                         challenge: LastThreeBlocksChallenger::generate(
                             &System::block_number(),
-                            &[]
+                            &[1]
                         ),
                     }),
                 ),
@@ -762,7 +762,6 @@ mod dispatch {
     /// a device from the attacker).
     #[test]
     fn fail_if_credentials_are_reused() {
-        let _ = env_logger::init();
         new_test_ext().execute_with(|| {
             assert_ok!(Pass::register(
                 RuntimeOrigin::root(),

--- a/pallets/pass/src/tests.rs
+++ b/pallets/pass/src/tests.rs
@@ -359,6 +359,7 @@ parameter_types! {
 
 mod add_device {
     use super::*;
+    use crate::DeviceOf;
 
     #[test]
     fn fails_if_bad_origin() {
@@ -417,7 +418,7 @@ mod add_device {
                 ExistentialDeposit::get()
                     + ItemStoragePrice::convert(Footprint::from_parts(
                         1,
-                        AccountId::max_encoded_len()
+                        DeviceOf::<Test>::max_encoded_len(),
                     ))
             ));
 

--- a/pallets/pass/src/types.rs
+++ b/pallets/pass/src/types.rs
@@ -156,10 +156,7 @@ where
             *maybe_consideration = Some((
                 consideration.update(
                     address,
-                    Footprint {
-                        count,
-                        size: Footprint::from_mel::<BlobType>().size,
-                    },
+                    Footprint::from_parts(count as usize, BlobType::max_encoded_len()),
                 )?,
                 count,
             ));

--- a/pallets/pass/src/types.rs
+++ b/pallets/pass/src/types.rs
@@ -182,7 +182,7 @@ pub use benchmarks::BenchmarkHelper;
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarks {
     use super::*;
-    use fc_traits_authn::HashedUserId;
+    use fc_traits_authn::{ExtrinsicContext, HashedUserId};
     use frame_system::pallet_prelude::OriginFor;
 
     #[cfg(feature = "runtime-benchmarks")]
@@ -192,7 +192,10 @@ mod benchmarks {
         I: 'static,
     {
         fn register_origin() -> OriginFor<T>;
-        fn device_attestation(device_id: fc_traits_authn::DeviceId) -> DeviceAttestationOf<T, I>;
-        fn credential(user_id: HashedUserId) -> CredentialOf<T, I>;
+        fn device_attestation(
+            device_id: fc_traits_authn::DeviceId,
+            xtc: &impl ExtrinsicContext,
+        ) -> DeviceAttestationOf<T, I>;
+        fn credential(user_id: HashedUserId, xtc: &impl ExtrinsicContext) -> CredentialOf<T, I>;
     }
 }

--- a/pallets/pass/src/types.rs
+++ b/pallets/pass/src/types.rs
@@ -183,7 +183,6 @@ pub use benchmarks::BenchmarkHelper;
 mod benchmarks {
     use super::*;
     use fc_traits_authn::{ExtrinsicContext, HashedUserId};
-    use frame_system::pallet_prelude::OriginFor;
 
     #[cfg(feature = "runtime-benchmarks")]
     pub trait BenchmarkHelper<T, I = ()>
@@ -191,7 +190,6 @@ mod benchmarks {
         T: Config<I>,
         I: 'static,
     {
-        fn register_origin() -> OriginFor<T>;
         fn device_attestation(
             device_id: fc_traits_authn::DeviceId,
             xtc: &impl ExtrinsicContext,

--- a/pallets/pass/src/weights.rs
+++ b/pallets/pass/src/weights.rs
@@ -9,8 +9,6 @@ use frame_support::weights::Weight;
 /// Weight functions needed for pallet_remark.
 pub trait WeightInfo {
 	fn register() -> Weight;
-	fn claim() -> Weight;
-	fn unreserve_uninitialized_account() -> Weight;
 	fn authenticate() -> Weight;
 	fn add_device() -> Weight;
 	fn remove_device() -> Weight;
@@ -23,28 +21,6 @@ pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	/// The range of component `l` is `[1, 1048576]`.
 	fn register() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 8_471_000 picoseconds.
-		Weight::from_parts(8_586_000, 0)
-			// Standard Error: 0
-			.saturating_add(Weight::from_parts(1_359, 0))
-	}
-
-	/// The range of component `l` is `[1, 1048576]`.
-	fn claim() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 8_471_000 picoseconds.
-		Weight::from_parts(8_586_000, 0)
-			// Standard Error: 0
-			.saturating_add(Weight::from_parts(1_359, 0))
-	}
-
-	/// The range of component `l` is `[1, 1048576]`.
-	fn unreserve_uninitialized_account() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`
@@ -121,28 +97,6 @@ impl WeightInfo for () {
 		Weight::from_parts(8_586_000, 0)
 			// Standard Error: 0
 			.saturating_add(Weight::from_parts(1_359, 0))
-	}
-
-	/// The range of component `l` is `[1, 1048576]`.
-	fn claim() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 8_471_000 picoseconds.
-		Weight::from_parts(8_586_000, 0)
-			// Standard Error: 0
-			.saturating_add(Weight::from_parts(1_359, 0))
-	}
-
-	/// The range of component `l` is `[1, 1048576]`.
-	fn unreserve_uninitialized_account() -> Weight {
-		// Proof Size summary in bytes:
-		//  Measured:  `0`
-		//  Estimated: `0`
-		// Minimum execution time: 8_471_000 picoseconds.
-		Weight::from_parts(0, 0)
-			// Standard Error: 0
-			.saturating_add(Weight::from_parts(0, 0))
 	}
 
 	/// The range of component `l` is `[1, 1048576]`.

--- a/traits/authn/src/lib.rs
+++ b/traits/authn/src/lib.rs
@@ -13,7 +13,7 @@ const LOG_TARGET: &str = "authn";
 pub mod composite_prelude {
     pub use crate::{
         Authenticator, AuthorityId, Challenge, Challenger, DeviceChallengeResponse, DeviceId,
-        HashedUserId, UserAuthenticator, UserChallengeResponse,
+        ExtrinsicContext, HashedUserId, UserAuthenticator, UserChallengeResponse,
     };
     pub use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
     pub use frame_support::{pallet_prelude::TypeInfo, traits::Get, DebugNoBound, EqNoBound};
@@ -48,15 +48,24 @@ pub type AuthorityId = [u8; 32];
 pub const HASHED_USER_ID_LEN: usize = 32;
 pub type HashedUserId = [u8; HASHED_USER_ID_LEN];
 
+/// An extrinsic context, provided by the Authenticator verification call. The type cannot be
+/// known by the challenger implementation, so the content would be handled as a slice of bytes.
+pub trait ExtrinsicContext: AsRef<[u8]> {}
+impl<T> ExtrinsicContext for T where T: AsRef<[u8]> {}
+
 /// Given some context it deterministically generates a "challenge" used by authenticators
 pub trait Challenger {
     type Context: Parameter;
 
-    fn generate(cx: &Self::Context) -> Challenge;
+    fn generate(cx: &Self::Context, xtc: &impl ExtrinsicContext) -> Challenge;
 
     /// Ensure that given the context produces the same challenge
-    fn check_challenge(cx: &Self::Context, challenge: &[u8]) -> Option<()> {
-        Self::generate(cx).eq(challenge).then_some(())
+    fn check_challenge(
+        cx: &Self::Context,
+        xtc: &impl ExtrinsicContext,
+        challenge: &[u8],
+    ) -> Option<()> {
+        Self::generate(cx, xtc).eq(challenge).then_some(())
     }
 }
 
@@ -67,7 +76,10 @@ pub trait Authenticator {
     type DeviceAttestation: DeviceChallengeResponse<CxOf<Self::Challenger>>;
     type Device: UserAuthenticator<Challenger = Self::Challenger>;
 
-    fn verify_device(attestation: Self::DeviceAttestation) -> Option<Self::Device> {
+    fn verify_device(
+        attestation: Self::DeviceAttestation,
+        xtc: &impl ExtrinsicContext,
+    ) -> Option<Self::Device> {
         log::trace!(target: LOG_TARGET, "Verifying device with attestation: {:?}", attestation);
 
         log::trace!(target: LOG_TARGET, "Assert authority {:?}", attestation.authority());
@@ -77,9 +89,9 @@ pub trait Authenticator {
             .then_some(())?;
         log::trace!(target: LOG_TARGET, "Authority verified");
 
-        let (cx, challenge) = attestation.used_challenge();
-        log::trace!(target: LOG_TARGET, "Check challenge {:?}", &challenge);
-        Self::Challenger::check_challenge(&cx, &challenge)?;
+        let (cx, challenge) = &attestation.used_challenge();
+        log::trace!(target: LOG_TARGET, "Check challenge {:?}", challenge);
+        Self::Challenger::check_challenge(cx, xtc, challenge)?;
         log::trace!(target: LOG_TARGET, "Challenge checked");
 
         log::trace!(target: LOG_TARGET, "Validate attestation");
@@ -99,7 +111,11 @@ pub trait UserAuthenticator: FullCodec + MaxEncodedLen + TypeInfo {
     type Challenger: Challenger;
     type Credential: UserChallengeResponse<CxOf<Self::Challenger>> + Send + Sync;
 
-    fn verify_user(&self, credential: &Self::Credential) -> Option<()> {
+    fn verify_user(
+        &self,
+        credential: &Self::Credential,
+        xtc: &impl ExtrinsicContext,
+    ) -> Option<()> {
         log::trace!(target: LOG_TARGET, "Verifying user for credential: {:?}", credential);
 
         log::trace!(target: LOG_TARGET, "Assert authority {:?}", credential.authority());
@@ -109,9 +125,9 @@ pub trait UserAuthenticator: FullCodec + MaxEncodedLen + TypeInfo {
             .then_some(())?;
         log::trace!(target: LOG_TARGET, "Authority verified");
 
-        let (cx, challenge) = credential.used_challenge();
-        log::trace!(target: LOG_TARGET, "Check challenge {:?}", &challenge);
-        Self::Challenger::check_challenge(&cx, &challenge)?;
+        let (cx, challenge) = &credential.used_challenge();
+        log::trace!(target: LOG_TARGET, "Check challenge {:?}", challenge);
+        Self::Challenger::check_challenge(cx, xtc, challenge)?;
         log::trace!(target: LOG_TARGET, "Challenge checked");
 
         log::trace!(target: LOG_TARGET, "Credential verified");

--- a/traits/authn/src/util.rs
+++ b/traits/authn/src/util.rs
@@ -92,7 +92,7 @@ pub mod dummy {
     use scale_info::TypeInfo;
 
     use crate::{
-        AuthorityId, Challenger, DeviceChallengeResponse, DeviceId, HashedUserId,
+        AuthorityId, Challenger, DeviceChallengeResponse, DeviceId, ExtrinsicContext, HashedUserId,
         UserChallengeResponse,
     };
 
@@ -149,7 +149,7 @@ pub mod dummy {
 
     impl Challenger for DummyChallenger {
         type Context = Self;
-        fn generate(cx: &Self::Context) -> crate::Challenge {
+        fn generate(cx: &Self::Context, _xtc: &impl ExtrinsicContext) -> crate::Challenge {
             [*cx; 32]
         }
     }


### PR DESCRIPTION
This PR includes some tests that are failing because it's possible to reuse some credentials that have been found out there to impersonate a pass account. This is completely inadmissible, as it poses a huge security risk, and must be fixed immediately. This PR fixes it.

Superseeds #40, as this solution uses the Transaction Extensions approach.

## How the fix works

1. `Challenger::generate` and `Challenger::validate_challenge` now include a new parameter: `extrinsic_context: impl AsRef<[u8]>`. This parameter should be processed by the challenger.
2. `Pass::authenticate` includes an additional parameter: `extrinsic_context: impl AsRef<[u8]>`.
3. We pass the encoded value of `inhereted_implication` from `TransactionExtensions::validate` to `Pass::authenticate`. 

Since this value changes on each new transaction (because the nonce changes) we ensure each 

## What to change in external authenticators

External authenticators now must include the external challenge using this calculation[^1]:

1. The extension version byte, call, extension and extension implicit should be encoded (by "extension" and its implicit we mean only the data associated with extensions that follow this one in the composite extension type);
1. The result of the encoding should then be hashed using the `BLAKE2_256` hasher;

```rs
// Step 1: encode the bytes
let encoded = (extension_version_byte, call, transaction_extensions, transaction_extensions_implicit_values).encode();
// Step 2: hash them
blake2_256(&encoded[..])
```

[^1]: As defined by [RFC 124](https://github.com/polkadot-fellows/RFCs/blob/0ac87dfeed91dcb3fd16f240fd783adf73c0e989/text/0124-extrinsic-version-5.md) from the Polkadot Fellowship.