### PR TITLE
chore: Migrate pallets to use `BlockNumberProvider`

### DIFF
--- a/pallets/communities/src/benchmarking.rs
+++ b/pallets/communities/src/benchmarking.rs
@@ -3,8 +3,8 @@ use super::*;
 
 use self::{
     types::{
-        AccountIdOf, AssetIdOf, CommunityIdOf, DecisionMethodFor, MembershipIdOf, NativeBalanceOf,
-        PalletsOriginOf, PollIndexOf, RuntimeCallFor, Vote,
+        AccountIdOf, AssetIdOf, BlockNumberFor, CommunityIdOf, DecisionMethodFor, MembershipIdOf,
+        NativeBalanceOf, PalletsOriginOf, PollIndexOf, RuntimeCallFor, Vote,
     },
     CommunityDecisionMethod, DecisionMethod, Event, FreezeReason, Pallet as Communities,
 };
@@ -15,10 +15,7 @@ use frame_support::traits::{
     fungibles::Mutate as FunsMutate,
     OriginTrait,
 };
-use frame_system::{
-    pallet_prelude::{BlockNumberFor, OriginFor},
-    RawOrigin,
-};
+use frame_system::{pallet_prelude::OriginFor, RawOrigin};
 use sp_runtime::traits::{Hash, StaticLookup};
 
 type RuntimeEventFor<T> = <T as Config>::RuntimeEvent;

--- a/pallets/communities/src/functions.rs
+++ b/pallets/communities/src/functions.rs
@@ -205,7 +205,7 @@ impl<T: Config> Pallet<T> {
                     &FreezeReason::VoteCasted.into(),
                     who,
                     amount_to_freeze,
-                    frame_support::traits::tokens::Fortitude::Polite,
+                    Polite,
                 )?;
             }
             _ => (),
@@ -217,11 +217,12 @@ impl<T: Config> Pallet<T> {
     pub(crate) fn do_dispatch_as_community_account(
         community_id: &CommunityIdOf<T>,
         call: RuntimeCallFor<T>,
-    ) -> DispatchResultWithPostInfo {
+    ) -> DispatchResult {
         let community_account = Self::community_account(community_id);
         let signer = frame_system::RawOrigin::Signed(community_account);
-
         call.dispatch(signer.into())
+            .map(|_| ())
+            .map_err(|e| e.error)
     }
 }
 

--- a/pallets/communities/src/mock.rs
+++ b/pallets/communities/src/mock.rs
@@ -163,35 +163,35 @@ parameter_types! {
     pub const RootAccount: AccountId = AccountId::new([0xff; 32]);
 }
 impl pallet_nfts::Config for Test {
-    type ApprovalsLimit = ();
-    type AttributeDepositBase = ();
-    type CollectionDeposit = ();
+    type RuntimeEvent = RuntimeEvent;
     type CollectionId = CommunityId;
+    type ItemId = MembershipId;
+    type Currency = ();
+    type ForceOrigin = EnsureRoot<AccountId>;
     type CreateOrigin = AsEnsureOriginWithArg<
         EitherOf<EnsureRootWithSuccess<AccountId, RootAccount>, EnsureSigned<AccountId>>,
     >;
-    type Currency = ();
-    type DepositPerByte = ();
-    type Features = ();
-    type ForceOrigin = EnsureRoot<AccountId>;
-    type ItemAttributesApprovalsLimit = ();
-    type ItemDeposit = ();
-    type ItemId = MembershipId;
-    type KeyLimit = ConstU32<64>;
     type Locker = ();
-    type MaxAttributesPerCall = ();
-    type MaxDeadlineDuration = ();
-    type MaxTips = ();
+    type CollectionDeposit = ();
+    type ItemDeposit = ();
     type MetadataDepositBase = ();
-    type OffchainPublic = AccountPublic;
-    type OffchainSignature = MultiSignature;
-    type RuntimeEvent = RuntimeEvent;
+    type AttributeDepositBase = ();
+    type DepositPerByte = ();
     type StringLimit = ();
+    type KeyLimit = ConstU32<64>;
     type ValueLimit = ConstU32<10>;
-    type WeightInfo = ();
-
+    type ApprovalsLimit = ();
+    type ItemAttributesApprovalsLimit = ();
+    type MaxTips = ();
+    type MaxDeadlineDuration = ();
+    type MaxAttributesPerCall = ();
+    type Features = ();
+    type OffchainSignature = MultiSignature;
+    type OffchainPublic = AccountPublic;
     #[cfg(feature = "runtime-benchmarks")]
     type Helper = NftsBenchmarksHelper;
+
+    type WeightInfo = ();
     type BlockNumberProvider = System;
 }
 
@@ -212,8 +212,8 @@ parameter_types! {
 }
 
 impl pallet_preimage::Config for Test {
-    type WeightInfo = ();
     type RuntimeEvent = RuntimeEvent;
+    type WeightInfo = ();
     type Currency = Balances;
     type ManagerOrigin = EnsureSigned<AccountId>;
     type Consideration = HoldConsideration<AccountId, Balances, PreimageHoldReason, ConvertDeposit>;
@@ -448,26 +448,28 @@ type AnyoneElsePays = EnsureSignedPays<Test, ConstU64<10>, RootAccount>;
 pub type MembershipsManager = NonFungiblesMemberships<Nfts>;
 
 impl Config for Test {
-    type PalletId = CommunitiesPalletId;
-    type CommunityId = CommunityId;
-    type MembershipId = MembershipId;
-
-    type Assets = Assets;
-    type AssetsFreezer = AssetsFreezer;
-    type Balances = Balances;
-    type ItemConfig = pallet_nfts::ItemConfig;
-    type MemberMgmt = MembershipsManager;
-    type Polls = Referenda;
+    type RuntimeEvent = RuntimeEvent;
+    type RuntimeOrigin = RuntimeOrigin;
+    type RuntimeCall = RuntimeCall;
+    type RuntimeFreezeReason = RuntimeFreezeReason;
+    type WeightInfo = WeightInfo;
 
     type CreateOrigin = EitherOf<RootCreatesCommunitiesForFree, AnyoneElsePays>;
     type AdminOrigin = EnsureCommunity<Self>;
     type MemberMgmtOrigin = EnsureCommunity<Self>;
 
-    type RuntimeCall = RuntimeCall;
-    type RuntimeOrigin = RuntimeOrigin;
-    type RuntimeEvent = RuntimeEvent;
-    type RuntimeFreezeReason = RuntimeFreezeReason;
-    type WeightInfo = WeightInfo;
+    type CommunityId = CommunityId;
+    type MembershipId = MembershipId;
+    type ItemConfig = pallet_nfts::ItemConfig;
+    type MemberMgmt = MembershipsManager;
+
+    type Polls = Referenda;
+    type Assets = Assets;
+    type AssetsFreezer = AssetsFreezer;
+    type Balances = Balances;
+    type BlockNumberProvider = System;
+
+    type PalletId = CommunitiesPalletId;
 
     #[cfg(feature = "runtime-benchmarks")]
     type BenchmarkHelper = CommunityBenchmarkHelper;
@@ -572,7 +574,7 @@ impl TestEnvBuilder {
         self
     }
 
-    pub(crate) fn build(self) -> sp_io::TestExternalities {
+    pub(crate) fn build(self) -> TestExternalities {
         let t = RuntimeGenesisConfig {
             assets: self.assets_config,
             balances: pallet_balances::GenesisConfig {

--- a/pallets/communities/src/types.rs
+++ b/pallets/communities/src/types.rs
@@ -1,6 +1,8 @@
+use super::*;
+
 use crate::{CommunityDecisionMethod, Config};
 use frame_contrib_traits::memberships::{Inspect, Rank};
-use frame_support::pallet_prelude::*;
+
 use frame_support::traits::{
     fungible::{self, Inspect as FunInspect},
     fungibles::{self, Inspect as FunsInspect},
@@ -20,10 +22,12 @@ pub type DecisionMethodFor<T> = DecisionMethod<AssetIdOf<T>, AssetBalanceOf<T>>;
 pub type PollIndexOf<T> = <<T as Config>::Polls as Polling<Tally<T>>>::Index;
 pub type AccountIdLookupOf<T> = <<T as frame_system::Config>::Lookup as StaticLookup>::Source;
 pub type PalletsOriginOf<T> =
-<<T as frame_system::Config>::RuntimeOrigin as frame_support::traits::OriginTrait>::PalletsOrigin;
+    <<T as frame_system::Config>::RuntimeOrigin as OriginTrait>::PalletsOrigin;
 pub type MembershipIdOf<T> = <T as Config>::MembershipId;
 pub type RuntimeCallFor<T> = <T as Config>::RuntimeCall;
 pub type RuntimeOriginFor<T> = <T as Config>::RuntimeOrigin;
+pub type BlockNumberFor<T> =
+    <<T as Config>::BlockNumberProvider as BlockNumberProvider>::BlockNumber;
 
 #[cfg(feature = "runtime-benchmarks")]
 pub type BenchmarkHelperOf<T> = <T as Config>::BenchmarkHelper;

--- a/pallets/gas-transaction-payment/src/benchmarking.rs
+++ b/pallets/gas-transaction-payment/src/benchmarking.rs
@@ -59,7 +59,7 @@ mod benchmarks {
             pays_fee: Pays::Yes,
         };
 
-        T::BenchmarkHelper::setup_account(&caller.clone().into(), info.call_weight)?;
+        T::BenchmarkHelper::setup_account(&caller.clone(), info.call_weight)?;
         let remaining = T::GasTank::check_available_gas(&caller, &info.call_weight)
             .expect("at least some remaining gas should be available after refueling; qed");
 

--- a/pallets/listings/src/impls.rs
+++ b/pallets/listings/src/impls.rs
@@ -6,7 +6,6 @@ type InventoryIdTuple<T, I> = (<T as Config<I>>::MerchantId, <T as Config<I>>::I
 mod inventory {
     use super::*;
     use nonfungibles_v2::{Create, InspectEnumerable, Mutate};
-    use pallet_nfts::{CollectionConfig, CollectionSettings};
 
     impl<T: Config<I>, I: 'static> InspectInventory for Pallet<T, I> {
         type MerchantId = T::MerchantId;
@@ -49,16 +48,7 @@ mod inventory {
 
     impl<T: Config<I>, I: 'static> InventoryLifecycle<T::AccountId> for Pallet<T, I> {
         fn create(id: InventoryIdTuple<T, I>, owner: &T::AccountId) -> DispatchResult {
-            T::Nonfungibles::create_collection_with_id(
-                id.into(),
-                owner,
-                owner,
-                &CollectionConfig {
-                    settings: CollectionSettings::all_enabled(),
-                    max_supply: None,
-                    mint_settings: Default::default(),
-                },
-            )
+            T::Nonfungibles::create_collection_with_id(id.into(), owner, owner, &Default::default())
         }
 
         fn archive(id: &InventoryIdTuple<T, I>) -> DispatchResult {
@@ -97,7 +87,6 @@ mod item {
     use super::*;
     use fc_traits_listings::item::{Item, ItemOf};
     use nonfungibles_v2::{InspectEnumerable, Mutate, Transfer};
-    use pallet_nfts::{ItemConfig, ItemSettings};
 
     impl<T: Config<I>, I: 'static> InspectItem<AccountIdOf<T>> for Pallet<T, I> {
         type MerchantId = T::MerchantId;
@@ -204,9 +193,7 @@ mod item {
                 inventory_id,
                 id,
                 &inventory_owner.clone(),
-                &ItemConfig {
-                    settings: ItemSettings::all_enabled(),
-                },
+                &Default::default(),
                 true,
             )?;
             T::Nonfungibles::set_typed_attribute(

--- a/pallets/listings/src/mock.rs
+++ b/pallets/listings/src/mock.rs
@@ -7,7 +7,9 @@ use frame_support::{
     derive_impl,
     traits::{EnsureOriginWithArg, Get},
 };
-use frame_system::{EnsureNever, EnsureRoot, EnsureSigned, RawOrigin};
+use frame_system::{
+    pallet_prelude::BlockNumberFor, EnsureNever, EnsureRoot, EnsureSigned, RawOrigin,
+};
 use sp_core::{parameter_types, ConstU32};
 use sp_io::TestExternalities;
 use sp_runtime::{
@@ -112,6 +114,7 @@ impl pallet_nfts::Config for Test {
 }
 #[cfg(feature = "runtime-benchmarks")]
 use core::marker::PhantomData;
+use sp_runtime::traits::BlockNumber;
 
 #[cfg(feature = "runtime-benchmarks")]
 pub struct OwnersCatalogBenchmarkHelper<T, I = ()>(PhantomData<(T, I)>);
@@ -202,16 +205,19 @@ impl<Id> EnsureOriginWithArg<RuntimeOrigin, InventoryId<AccountIdBytes, Id>>
 impl pallet_listings::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type WeightInfo = ();
-    type Balances = Balances;
-    type Assets = Assets;
-    type Nonfungibles = ListingsCatalog;
-    type NonfungiblesKeyLimit = <Self as pallet_nfts::Config>::KeyLimit;
-    type NonfungiblesValueLimit = <Self as pallet_nfts::Config>::ValueLimit;
     type CreateInventoryOrigin = EnsureAccountIdInventories;
     type InventoryAdminOrigin = EnsureAccountIdInventories;
     type MerchantId = AccountIdBytes;
     type InventoryId = u32;
     type ItemSKU = u32;
+    type CollectionConfig =
+        pallet_nfts::CollectionConfig<Balance, BlockNumberFor<Self>, InventoryIdFor<Self>>;
+    type ItemConfig = pallet_nfts::ItemConfig;
+    type Balances = Balances;
+    type Assets = Assets;
+    type Nonfungibles = ListingsCatalog;
+    type NonfungiblesKeyLimit = <Self as pallet_nfts::Config>::KeyLimit;
+    type NonfungiblesValueLimit = <Self as pallet_nfts::Config>::ValueLimit;
     #[cfg(feature = "runtime-benchmarks")]
     type BenchmarkHelper = Self;
 }

--- a/pallets/listings/src/mock.rs
+++ b/pallets/listings/src/mock.rs
@@ -108,69 +108,9 @@ impl pallet_nfts::Config for Test {
     type OffchainSignature = MultiSignature;
     type OffchainPublic = AccountPublic;
     #[cfg(feature = "runtime-benchmarks")]
-    type Helper = OwnersCatalogBenchmarkHelper<Self>;
+    type Helper = benchmarks::OwnersCatalogBenchmarkHelper<Self>;
     type WeightInfo = ();
     type BlockNumberProvider = System;
-}
-#[cfg(feature = "runtime-benchmarks")]
-use core::marker::PhantomData;
-use sp_runtime::traits::BlockNumber;
-
-#[cfg(feature = "runtime-benchmarks")]
-pub struct OwnersCatalogBenchmarkHelper<T, I = ()>(PhantomData<(T, I)>);
-
-#[cfg(feature = "runtime-benchmarks")]
-impl<T, I: 'static>
-    pallet_nfts::BenchmarkHelper<
-        InventoryIdFor<Test>,
-        ItemIdOf<Test>,
-        sp_runtime::MultiSigner,
-        sp_runtime::AccountId32,
-        MultiSignature,
-    > for OwnersCatalogBenchmarkHelper<T, I>
-where
-    T: pallet_nfts::Config<I>,
-{
-    fn collection(i: u16) -> InventoryIdFor<Test> {
-        fn convert(i: u16) -> [u8; 32] {
-            let high = (i >> 8) as u8;
-            let low = (i & 0xFF) as u8;
-            let mut j = [0u8; 32];
-
-            for idx in 0..16 {
-                j[2 * idx] = high;
-                j[2 * idx + 1] = low;
-            }
-
-            j
-        }
-
-        InventoryId(convert(i), 1u16.into())
-    }
-
-    fn item(i: u16) -> ItemIdOf<Test> {
-        i.into()
-    }
-
-    fn signer() -> (sp_runtime::MultiSigner, sp_runtime::AccountId32) {
-        <() as pallet_nfts::BenchmarkHelper<
-            u16,
-            u16,
-            sp_runtime::MultiSigner,
-            sp_runtime::AccountId32,
-            MultiSignature,
-        >>::signer()
-    }
-
-    fn sign(signer: &sp_runtime::MultiSigner, message: &[u8]) -> MultiSignature {
-        <() as pallet_nfts::BenchmarkHelper<
-            u16,
-            u16,
-            sp_runtime::MultiSigner,
-            sp_runtime::AccountId32,
-            MultiSignature,
-        >>::sign(signer, message)
-    }
 }
 
 pub struct EnsureAccountIdInventories;
@@ -223,9 +163,71 @@ impl pallet_listings::Config for Test {
 }
 
 #[cfg(feature = "runtime-benchmarks")]
-impl pallet_listings::BenchmarkHelper<InventoryIdFor<Test>> for Test {
-    fn inventory_id() -> InventoryIdFor<Test> {
-        InventoryId([0u8; 32], 0)
+mod benchmarks {
+    use super::*;
+    use pallet_nfts::BenchmarkHelper;
+    use sp_runtime::{AccountId32, MultiSignature, MultiSigner};
+
+    pub struct OwnersCatalogBenchmarkHelper<T, I = ()>(core::marker::PhantomData<(T, I)>);
+
+    impl<T, I: 'static>
+        BenchmarkHelper<
+            InventoryIdFor<Test>,
+            ItemIdOf<Test>,
+            MultiSigner,
+            AccountId32,
+            MultiSignature,
+        > for OwnersCatalogBenchmarkHelper<T, I>
+    where
+        T: pallet_nfts::Config<I>,
+    {
+        fn collection(i: u16) -> InventoryIdFor<Test> {
+            fn convert(i: u16) -> [u8; 32] {
+                let high = (i >> 8) as u8;
+                let low = (i & 0xFF) as u8;
+                let mut j = [0u8; 32];
+
+                for idx in 0..16 {
+                    j[2 * idx] = high;
+                    j[2 * idx + 1] = low;
+                }
+
+                j
+            }
+
+            InventoryId(convert(i), 1u16.into())
+        }
+
+        fn item(i: u16) -> ItemIdOf<Test> {
+            i.into()
+        }
+
+        fn signer() -> (sp_runtime::MultiSigner, sp_runtime::AccountId32) {
+            <() as BenchmarkHelper<
+                u16,
+                u16,
+                sp_runtime::MultiSigner,
+                sp_runtime::AccountId32,
+                MultiSignature,
+            >>::signer()
+        }
+
+        fn sign(signer: &sp_runtime::MultiSigner, message: &[u8]) -> MultiSignature {
+            <() as BenchmarkHelper<
+                u16,
+                u16,
+                sp_runtime::MultiSigner,
+                sp_runtime::AccountId32,
+                MultiSignature,
+            >>::sign(signer, message)
+        }
+    }
+
+    #[cfg(feature = "runtime-benchmarks")]
+    impl crate::BenchmarkHelper<InventoryIdFor<Test>> for Test {
+        fn inventory_id() -> InventoryIdFor<Test> {
+            InventoryId([0u8; 32], 0)
+        }
     }
 }
 

--- a/pallets/listings/src/types.rs
+++ b/pallets/listings/src/types.rs
@@ -69,6 +69,7 @@ pub type ItemInfo<Name, Price> = (Name, Option<Price>);
     Encode,
     Decode,
     DecodeWithMemTracking,
+    Default,
     Copy,
     Clone,
     PartialEq,

--- a/pallets/orders/src/mock.rs
+++ b/pallets/orders/src/mock.rs
@@ -352,6 +352,7 @@ impl Config for Test {
     type Listings = Listings;
     type Payments = Payments;
     type Scheduler = Scheduler;
+    type BlockNumberProvider = System;
     type MaxLifetimeForCheckoutOrder = MaxLifetimeForCheckoutOrder;
     type MaxCartLen = MaxCartLen;
     type MaxItemLen = MaxItemLen;

--- a/pallets/orders/src/mock.rs
+++ b/pallets/orders/src/mock.rs
@@ -292,6 +292,7 @@ impl fc_pallet_payments::Config for Test {
     type RuntimeCall = RuntimeCall;
     type Assets = Assets;
     type AssetsHold = AssetsHolder;
+    type BlockNumberProvider = System;
     type FeeHandler = ();
     type SenderOrigin = EnsureSigned<AccountId>;
     type BeneficiaryOrigin = EnsureSigned<AccountId>;

--- a/pallets/orders/src/mock.rs
+++ b/pallets/orders/src/mock.rs
@@ -221,17 +221,19 @@ where
 impl fc_pallet_listings::Config for Test {
     type RuntimeEvent = RuntimeEvent;
     type WeightInfo = ();
-    type Balances = Balances;
-    type Assets = Assets;
-    type Nonfungibles = ListingsCatalog;
-    type NonfungiblesKeyLimit = ();
-    type NonfungiblesValueLimit = ();
     type CreateInventoryOrigin = EnsureSigned<AccountId>;
     type InventoryAdminOrigin = EnsureSigned<AccountId>;
     type MerchantId = [u8; 32];
     type InventoryId = u32;
     type ItemSKU = u32;
-
+    type CollectionConfig =
+        pallet_nfts::CollectionConfig<Balance, BlockNumberFor<Self>, InventoryIdFor<Self>>;
+    type ItemConfig = pallet_nfts::ItemConfig;
+    type Balances = Balances;
+    type Assets = Assets;
+    type Nonfungibles = ListingsCatalog;
+    type NonfungiblesKeyLimit = ();
+    type NonfungiblesValueLimit = ();
     #[cfg(feature = "runtime-benchmarks")]
     type BenchmarkHelper = Self;
 }

--- a/pallets/orders/src/types.rs
+++ b/pallets/orders/src/types.rs
@@ -1,6 +1,8 @@
 use super::*;
 
 pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
+pub type BlockNumberFor<T, I> =
+    <<T as Config<I>>::BlockNumberProvider as BlockNumberProvider>::BlockNumber;
 pub(crate) type MerchantIdOf<T, I = ()> =
     <<T as Config<I>>::Listings as InspectItem<AccountIdOf<T>>>::MerchantId;
 pub type InventoryIdOf<T, I = ()> =

--- a/pallets/pass/src/mock.rs
+++ b/pallets/pass/src/mock.rs
@@ -177,6 +177,7 @@ impl Config for Test {
     type Balances = Balances;
     type Authenticator = PassAuthenticator;
     type Scheduler = Scheduler;
+    type BlockNumberProvider = System;
     type RegistrarConsideration = RootDoesNotPayConsideration<
         HoldConsideration<AccountId, Balances, HoldAccountRegistration, RegistrationStoragePrice>,
     >;

--- a/pallets/pass/src/types.rs
+++ b/pallets/pass/src/types.rs
@@ -1,35 +1,24 @@
-use crate::Config;
+use super::*;
 
-use alloc::borrow::ToOwned;
-use codec::{Decode, EncodeLike};
-use core::marker::PhantomData;
-use fc_traits_authn::{
-    composite_prelude::{Encode, MaxEncodedLen, TypeInfo},
-    HashedUserId, HASHED_USER_ID_LEN,
-};
-use frame_support::{
-    dispatch::DispatchResult,
-    traits::{fungible::Inspect, Consideration, Footprint, MapSuccess},
-};
+use codec::EncodeLike;
+use frame_support::traits::MapSuccess;
 use frame_system::EnsureSigned;
-use sp_core::TypedGet;
 use sp_runtime::{
     morph_types,
-    traits::StaticLookup,
     traits::{Hash, TrailingZeroInput},
-    DispatchError, Saturating,
+    Saturating,
 };
 
 // pub type HashedUserId<T> = <T as frame_system::Config>::Hash;
 pub(crate) type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
+pub(crate) type BlockNumberFor<T, I> =
+    <<T as Config<I>>::BlockNumberProvider as BlockNumberProvider>::BlockNumber;
 pub type ContextOf<T, I = ()> =
-<<<T as Config<I>>::Authenticator as fc_traits_authn::Authenticator>::Challenger as fc_traits_authn::Challenger>::Context;
-pub type DeviceOf<T, I = ()> =
-    <<T as Config<I>>::Authenticator as fc_traits_authn::Authenticator>::Device;
-pub type CredentialOf<T, I = ()> =
-    <DeviceOf<T, I> as fc_traits_authn::UserAuthenticator>::Credential;
+    <<<T as Config<I>>::Authenticator as Authenticator>::Challenger as Challenger>::Context;
+pub type DeviceOf<T, I = ()> = <<T as Config<I>>::Authenticator as Authenticator>::Device;
+pub type CredentialOf<T, I = ()> = <DeviceOf<T, I> as UserAuthenticator>::Credential;
 pub type DeviceAttestationOf<T, I = ()> =
-    <<T as Config<I>>::Authenticator as fc_traits_authn::Authenticator>::DeviceAttestation;
+    <<T as Config<I>>::Authenticator as Authenticator>::DeviceAttestation;
 pub type AccountIdLookupOf<T> = <<T as frame_system::Config>::Lookup as StaticLookup>::Source;
 pub type BalanceOf<T, I = ()> =
     <<T as Config<I>>::Balances as Inspect<<T as frame_system::Config>::AccountId>>::Balance;

--- a/pallets/payments/src/benchmarking.rs
+++ b/pallets/payments/src/benchmarking.rs
@@ -184,7 +184,7 @@ mod benchmarks {
         #[extrinsic_call]
         _(RawOrigin::Signed(sender.clone()), payment_id);
 
-        let current_block = frame_system::Pallet::<T>::block_number();
+        let current_block = T::BlockNumberProvider::current_block_number();
         assert_has_event!(
             Event::PaymentCreatorRequestedRefund { expiry, .. }
             if expiry == (current_block + T::CancelBufferBlockLength::get())

--- a/pallets/payments/src/mock.rs
+++ b/pallets/payments/src/mock.rs
@@ -264,6 +264,7 @@ impl Config for Test {
     type RuntimeCall = RuntimeCall;
     type Assets = Assets;
     type AssetsHold = AssetsHolder;
+    type BlockNumberProvider = System;
     type FeeHandler = MockFeeHandler;
     type SenderOrigin = EnsureSigned<AccountId>;
     type BeneficiaryOrigin = EnsureSigned<AccountId>;

--- a/pallets/payments/src/tests.rs
+++ b/pallets/payments/src/tests.rs
@@ -1,15 +1,12 @@
 use super::*;
-use crate::{
-    mock::*,
-    types::{PaymentDetail, PaymentState},
-    Payment as PaymentStore, PaymentId,
-};
 use frame_support::{
     assert_err, assert_ok, traits::fungibles, weights::constants::WEIGHT_REF_TIME_PER_NANOS,
 };
+use mock::{Hooks, *};
+use sp_runtime::Perbill;
+use types::{PaymentDetail, PaymentState};
 use weights::SubstrateWeight;
-
-use sp_runtime::{BoundedVec, Perbill};
+use Payment as PaymentStore;
 
 const ASSERT_PAYMENT_CREATION: bool = true;
 

--- a/pallets/payments/src/types.rs
+++ b/pallets/payments/src/types.rs
@@ -1,16 +1,16 @@
-#![allow(unused_qualifications)]
-use crate::*;
+use super::*;
 
-use alloc::{collections::btree_map::BTreeMap, vec::Vec};
-use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
-use frame_system::pallet_prelude::BlockNumberFor;
+use alloc::collections::btree_map::BTreeMap;
+use codec::DecodeWithMemTracking;
 use scale_info::TypeInfo;
-use sp_runtime::{traits::Zero, BoundedVec, Percent, Saturating};
+use sp_runtime::{traits::Zero, BoundedVec};
 
+pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
+pub type BlockNumberFor<T> =
+    <<T as Config>::BlockNumberProvider as BlockNumberProvider>::BlockNumber;
 // This pallet's asset id and balance type.
 pub type AssetIdOf<T> =
     <<T as Config>::Assets as FunsInspect<<T as frame_system::Config>::AccountId>>::AssetId;
-pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
 pub type MaxFeesOf<T> = <T as Config>::MaxFees;
 pub type BalanceOf<T> =
     <<T as Config>::Assets as FunsInspect<<T as frame_system::Config>::AccountId>>::Balance;

--- a/pallets/referenda-tracks/src/lib.rs
+++ b/pallets/referenda-tracks/src/lib.rs
@@ -1,19 +1,4 @@
-// This file is part of Substrate.
-
-// Copyright (C) Parity Technologies (UK) Ltd.
-// SPDX-License-Identifier: Apache-2.0
-
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// 	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+#![cfg_attr(not(feature = "std"), no_std)]
 
 //! # Referenda Tracks Pallet
 //!
@@ -31,8 +16,6 @@
 //! - [`insert`][`crate::Pallet::insert`] - Insert a new referenda Track.
 //! - [`update`][`crate::Pallet::update`] - Update the configuration of an existing referenda Track.
 //! - [`remove`][`crate::Pallet::remove`] - Remove an existing track
-
-#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
 

--- a/traits/authn/src/util.rs
+++ b/traits/authn/src/util.rs
@@ -111,7 +111,7 @@ pub mod dummy {
         EqNoBound,
     )]
     #[scale_info(skip_type_params(A))]
-    pub struct DummyAttestation<A>(bool, Option<DeviceId>, PhantomData<(A)>);
+    pub struct DummyAttestation<A>(bool, Option<DeviceId>, PhantomData<A>);
 
     impl<A> DummyAttestation<A> {
         pub fn new(value: bool, device_id: DeviceId) -> Self {

--- a/traits/gas-tank/src/lib.rs
+++ b/traits/gas-tank/src/lib.rs
@@ -1,7 +1,6 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use frame_support::Parameter;
-use sp_runtime::traits::BlockNumber;
 use sp_runtime::DispatchResult;
 
 #[cfg(test)]
@@ -43,7 +42,7 @@ pub trait GasFueler {
 pub trait MakeTank {
     type TankId: Parameter;
     type Gas: Parameter;
-    type BlockNumber: BlockNumber;
+    type BlockNumber;
 
     /// Creates a new tank, allowing to specify a max gas `capacity` and a `periodicity` after
     /// which the tank gets renewed.


### PR DESCRIPTION
This Pull Request ensures that the pallets don't depend on `System` as the block number provider, except on testing, and instead defines `Config` types to ensure that whether it's necessary to inject a `BlockNumberFor` or get the current block number, that's done accordingly using the specified provider