### PR TITLE
feat(fc-pallet-pass): ensure device addition is unique and bound to a specific pass account id

### DIFF
--- a/pallets/pass/src/benchmarking.rs
+++ b/pallets/pass/src/benchmarking.rs
@@ -41,7 +41,8 @@ fn do_register<T: Config<I>, I: 'static>(
 ) -> Result<DeviceId, BenchmarkError> {
     let origin = prepare_register::<T, I>(hashed_user_id)
         .map_err(|_| BenchmarkError::Stop("Cannot prepare origin"))?;
-    let attestation = T::BenchmarkHelper::device_attestation(&[]);
+    let account_address = Pallet::<T, I>::address_for(hashed_user_id);
+    let attestation = T::BenchmarkHelper::device_attestation(&account_address.encode());
     Pallet::<T, I>::register(origin, hashed_user_id, attestation.clone())
         .map(|_| *(attestation.device_id()))
         .map_err(|_| BenchmarkError::Stop("Cannot register pass account"))
@@ -76,7 +77,7 @@ mod benchmarks {
         let origin = prepare_register::<T, I>(user_id)?;
 
         let account_id = Pallet::<T, I>::address_for(user_id);
-        let attestation = T::BenchmarkHelper::device_attestation(&[]);
+        let attestation = T::BenchmarkHelper::device_attestation(&account_id.encode());
         let device_id = *(attestation.clone().device_id());
 
         #[extrinsic_call]
@@ -143,7 +144,7 @@ mod benchmarks {
         do_register::<T, I>(user_id)?;
 
         let address = Pallet::<T, I>::address_for(user_id);
-        let attestation = T::BenchmarkHelper::device_attestation(&[]);
+        let attestation = T::BenchmarkHelper::device_attestation(&address.encode());
         let new_device_id = *(attestation.clone().device_id());
         T::DeviceConsideration::ensure_successful(
             &address,
@@ -172,7 +173,7 @@ mod benchmarks {
         do_register::<T, I>(user_id)?;
 
         let address = Pallet::<T, I>::address_for(user_id);
-        let attestation = T::BenchmarkHelper::device_attestation(&[]);
+        let attestation = T::BenchmarkHelper::device_attestation(&address.encode());
         let new_device_id = *(attestation.clone().device_id());
         T::DeviceConsideration::ensure_successful(
             &address,

--- a/pallets/pass/src/tests.rs
+++ b/pallets/pass/src/tests.rs
@@ -223,7 +223,10 @@ mod authenticate {
                 PassDeviceAttestation::AuthenticatorB(authenticator_b::DeviceAttestation {
                     device_id: THE_DEVICE,
                     context: System::block_number(),
-                    challenge: LastThreeBlocksChallenger::generate(&System::block_number(), &[]),
+                    challenge: LastThreeBlocksChallenger::generate(
+                        &System::block_number(),
+                        &Address::get(),
+                    ),
                 }),
             ));
 
@@ -255,7 +258,10 @@ mod authenticate {
                 PassDeviceAttestation::AuthenticatorB(authenticator_b::DeviceAttestation {
                     device_id: THE_DEVICE,
                     context: System::block_number(),
-                    challenge: LastThreeBlocksChallenger::generate(&System::block_number(), &[]),
+                    challenge: LastThreeBlocksChallenger::generate(
+                        &System::block_number(),
+                        &Address::get(),
+                    ),
                 }),
             ));
 
@@ -303,7 +309,10 @@ mod authenticate {
                 PassDeviceAttestation::AuthenticatorB(authenticator_b::DeviceAttestation {
                     device_id: OTHER_DEVICE,
                     context: System::block_number(),
-                    challenge: LastThreeBlocksChallenger::generate(&System::block_number(), &[]),
+                    challenge: LastThreeBlocksChallenger::generate(
+                        &System::block_number(),
+                        &address,
+                    ),
                 }),
             )
             .expect("adding device on an existing account works; qed");
@@ -336,7 +345,10 @@ mod authenticate {
                 PassDeviceAttestation::AuthenticatorB(authenticator_b::DeviceAttestation {
                     device_id: THE_DEVICE,
                     context: System::block_number(),
-                    challenge: LastThreeBlocksChallenger::generate(&System::block_number(), &[]),
+                    challenge: LastThreeBlocksChallenger::generate(
+                        &System::block_number(),
+                        &Address::get(),
+                    ),
                 }),
             ));
             assert_ok!(Pass::register(
@@ -345,7 +357,10 @@ mod authenticate {
                 PassDeviceAttestation::AuthenticatorB(authenticator_b::DeviceAttestation {
                     device_id: OTHER_DEVICE,
                     context: System::block_number(),
-                    challenge: LastThreeBlocksChallenger::generate(&System::block_number(), &[]),
+                    challenge: LastThreeBlocksChallenger::generate(
+                        &System::block_number(),
+                        &AddressB::get(),
+                    ),
                 }),
             ));
 
@@ -378,7 +393,10 @@ mod authenticate {
                 PassDeviceAttestation::AuthenticatorB(authenticator_b::DeviceAttestation {
                     device_id: THE_DEVICE,
                     context: System::block_number(),
-                    challenge: LastThreeBlocksChallenger::generate(&System::block_number(), &[]),
+                    challenge: LastThreeBlocksChallenger::generate(
+                        &System::block_number(),
+                        &Address::get(),
+                    ),
                 }),
             ));
 
@@ -426,7 +444,10 @@ mod authenticate {
                 PassDeviceAttestation::AuthenticatorB(authenticator_b::DeviceAttestation {
                     device_id: THE_DEVICE,
                     context: System::block_number(),
-                    challenge: LastThreeBlocksChallenger::generate(&System::block_number(), &[]),
+                    challenge: LastThreeBlocksChallenger::generate(
+                        &System::block_number(),
+                        &Address::get(),
+                    ),
                 }),
             ));
 
@@ -455,7 +476,10 @@ mod authenticate {
                 PassDeviceAttestation::AuthenticatorB(authenticator_b::DeviceAttestation {
                     device_id: THE_DEVICE,
                     context: System::block_number(),
-                    challenge: LastThreeBlocksChallenger::generate(&System::block_number(), &[]),
+                    challenge: LastThreeBlocksChallenger::generate(
+                        &System::block_number(),
+                        &Address::get(),
+                    ),
                 }),
             ));
 
@@ -543,6 +567,26 @@ mod add_device {
                     ),
                 ),
                 DispatchError::BadOrigin
+            );
+        });
+    }
+
+    #[test]
+    fn fails_if_invalid_challenge() {
+        prepare(AccountNameA::get()).execute_with(|| {
+            assert_noop!(
+                Pass::add_device(
+                    RuntimeOrigin::signed(Address::get()),
+                    PassDeviceAttestation::AuthenticatorB(authenticator_b::DeviceAttestation {
+                        device_id: OTHER_DEVICE,
+                        context: System::block_number(),
+                        challenge: LastThreeBlocksChallenger::generate(
+                            &System::block_number(),
+                            &[]
+                        ),
+                    }),
+                ),
+                Error::<Test>::DeviceAttestationInvalid
             );
         });
     }
@@ -906,7 +950,10 @@ mod dispatch {
                 PassDeviceAttestation::AuthenticatorB(authenticator_b::DeviceAttestation {
                     device_id: THE_DEVICE,
                     context: System::block_number(),
-                    challenge: LastThreeBlocksChallenger::generate(&System::block_number(), &[]),
+                    challenge: LastThreeBlocksChallenger::generate(
+                        &System::block_number(),
+                        &Address::get(),
+                    ),
                 }),
             ));
             assert_ok!(Balances::mint_into(&Address::get(), Balance::MAX));


### PR DESCRIPTION
Fixes #62