### PR TITLE
refactor(traits-authn): gate frame-support behind `runtime` feature

### DIFF
--- a/pallets/pass/Cargo.toml
+++ b/pallets/pass/Cargo.toml
@@ -12,7 +12,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 codec.workspace = true
-fc-traits-authn.workspace = true
+fc-traits-authn = { workspace = true, features = ["runtime"] }
 frame-benchmarking = { workspace = true, optional = true }
 frame-support.workspace = true
 frame-system.workspace = true

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 version = "0.1.0"
 
 [dependencies]
-fc-traits-authn.workspace = true
+fc-traits-authn = { workspace = true, features = ["runtime"] }
 fc-traits-gas-tank.workspace = true
 fc-traits-listings.workspace = true
 fc-traits-memberships.workspace = true

--- a/traits/authn/Cargo.toml
+++ b/traits/authn/Cargo.toml
@@ -8,11 +8,12 @@ version = "0.1.0"
 
 [dependencies]
 codec.workspace = true
-frame-support.workspace = true
+frame-support = { workspace = true, optional = true }
 fc-traits-authn-proc.workspace = true
 log.workspace = true
 scale-info.workspace = true
 
 [features]
-default = ["std"]
-std = ["codec/std", "frame-support/std", "log/std", "scale-info/std"]
+default = ["std", "runtime"]
+runtime = ["dep:frame-support"]
+std = ["codec/std", "frame-support?/std", "log/std", "scale-info/std"]

--- a/traits/authn/src/lib.rs
+++ b/traits/authn/src/lib.rs
@@ -1,15 +1,20 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(feature = "runtime")]
 use codec::{FullCodec, MaxEncodedLen};
+#[cfg(feature = "runtime")]
 use frame_support::{traits::Get, Parameter};
+#[cfg(feature = "runtime")]
 use scale_info::TypeInfo;
 
 pub mod util;
 
 pub use fc_traits_authn_proc::composite_authenticator;
 
+#[cfg(feature = "runtime")]
 const LOG_TARGET: &str = "authn";
 
+#[cfg(feature = "runtime")]
 pub mod prelude {
     pub use crate::{
         Authenticator, AuthorityId, Challenge, Challenger, DeviceChallengeResponse, DeviceId,
@@ -43,6 +48,7 @@ macro_rules! composite_authenticators {
 // A reasonably sized secure challenge
 const CHALLENGE_SIZE: usize = 32;
 pub type Challenge = [u8; CHALLENGE_SIZE];
+#[cfg(feature = "runtime")]
 type CxOf<C> = <C as Challenger>::Context;
 
 pub type DeviceId = [u8; 32];
@@ -56,6 +62,7 @@ pub trait ExtrinsicContext: AsRef<[u8]> + core::fmt::Debug {}
 impl<T> ExtrinsicContext for T where T: AsRef<[u8]> + core::fmt::Debug {}
 
 /// Given some context it deterministically generates a "challenge" used by authenticators
+#[cfg(feature = "runtime")]
 pub trait Challenger {
     type Context: Parameter;
 
@@ -72,6 +79,7 @@ pub trait Challenger {
 }
 
 /// Authenticator is used to verify authentication devices that in turn are used to verify users
+#[cfg(feature = "runtime")]
 pub trait Authenticator {
     type Authority: Get<AuthorityId>;
     type Challenger: Challenger;
@@ -108,6 +116,7 @@ pub trait Authenticator {
 }
 
 /// A device capable of verifying a user provided credential
+#[cfg(feature = "runtime")]
 pub trait UserAuthenticator: FullCodec + MaxEncodedLen + TypeInfo {
     type Authority: Get<AuthorityId>;
     type Challenger: Challenger;
@@ -145,6 +154,7 @@ pub trait UserAuthenticator: FullCodec + MaxEncodedLen + TypeInfo {
 }
 
 /// A response to a challenge for creating a new authentication device
+#[cfg(feature = "runtime")]
 pub trait DeviceChallengeResponse<Cx>: Parameter {
     fn is_valid(&self) -> bool;
     fn used_challenge(&self) -> (Cx, Challenge);
@@ -153,6 +163,7 @@ pub trait DeviceChallengeResponse<Cx>: Parameter {
 }
 
 /// A response to a challenge for identifying a user
+#[cfg(feature = "runtime")]
 pub trait UserChallengeResponse<Cx>: Parameter {
     fn is_valid(&self) -> bool;
     fn used_challenge(&self) -> (Cx, Challenge);

--- a/traits/authn/src/util.rs
+++ b/traits/authn/src/util.rs
@@ -1,223 +1,236 @@
-use core::marker::PhantomData;
-
-use codec::{Decode, DecodeWithMemTracking, Encode, FullCodec, MaxEncodedLen};
-use frame_support::{sp_runtime::traits::TrailingZeroInput, traits::Get, PalletId};
-use scale_info::TypeInfo;
-
-use crate::{
-    Authenticator, AuthorityId, Challenger, CxOf, DeviceChallengeResponse, DeviceId,
-    UserAuthenticator, UserChallengeResponse,
-};
-
-type ChallengerOf<Dev> = <Dev as UserAuthenticator>::Challenger;
-
-#[derive(Encode, Decode, DecodeWithMemTracking, TypeInfo, Clone, PartialEq, Eq, Debug)]
-#[scale_info(skip_type_params(Id))]
-pub struct AuthorityFromPalletId<Id>(PhantomData<Id>);
-
-impl<Id: Get<PalletId>> Get<AuthorityId> for AuthorityFromPalletId<Id> {
-    fn get() -> AuthorityId {
-        Decode::decode(&mut TrailingZeroInput::new(&Id::get().0))
-            .expect("Size of PalletId is less than 32 bytes; qed")
-    }
-}
-
-#[derive(Encode, Decode, DecodeWithMemTracking, TypeInfo, Clone, PartialEq, Eq, Debug)]
-#[scale_info(skip_type_params(Dev, Att))]
-/// Convenient auto-implementor of the Authenticator trait
-pub struct Auth<Dev, Att>(PhantomData<(Dev, Att)>);
-
-impl<Dev, Att> Authenticator for Auth<Dev, Att>
-where
-    Att: DeviceChallengeResponse<CxOf<ChallengerOf<Dev>>>,
-    Dev: UserAuthenticator + From<Att>,
-{
-    type Authority = <Dev as UserAuthenticator>::Authority;
-    type Challenger = ChallengerOf<Dev>;
-    type DeviceAttestation = Att;
-    type Device = Dev;
-
-    fn unpack_device(attestation: Self::DeviceAttestation) -> Self::Device {
-        attestation.into()
-    }
-}
-
 pub trait VerifyCredential<Cred> {
     fn verify(&mut self, credential: &Cred) -> Option<()>;
 }
 
-/// Convenient auto-implementor of the UserAuthenticator trait
-#[derive(Encode, Decode, DecodeWithMemTracking, TypeInfo, Clone, PartialEq, Eq, Debug)]
-#[scale_info(skip_type_params(A, Ch, Cred))]
-pub struct Dev<T, A, Ch, Cred>(T, PhantomData<(A, Ch, Cred)>);
+#[cfg(feature = "runtime")]
+mod runtime {
+    use core::marker::PhantomData;
 
-impl<T, A, Ch, Cred> Dev<T, A, Ch, Cred> {
-    pub fn new(t: T) -> Self {
-        Self(t, PhantomData)
-    }
-}
-
-impl<T, A, Ch, Cred> UserAuthenticator for Dev<T, A, Ch, Cred>
-where
-    T: VerifyCredential<Cred> + AsRef<DeviceId> + FullCodec + MaxEncodedLen + TypeInfo + 'static,
-    A: Get<AuthorityId> + 'static,
-    Ch: Challenger + 'static,
-    Cred: UserChallengeResponse<Ch::Context> + 'static + Send + Sync,
-{
-    type Authority = A;
-    type Challenger = Ch;
-    type Credential = Cred;
-
-    fn verify_credential(&mut self, credential: &Self::Credential) -> Option<()> {
-        self.0.verify(credential)
-    }
-
-    fn device_id(&self) -> &DeviceId {
-        self.0.as_ref()
-    }
-}
-
-impl<T: MaxEncodedLen, A, Ch, Cr> MaxEncodedLen for Dev<T, A, Ch, Cr> {
-    fn max_encoded_len() -> usize {
-        T::max_encoded_len()
-    }
-}
-
-pub mod dummy {
-    use super::*;
-    use frame_support::{
-        parameter_types, sp_runtime::str_array as s, CloneNoBound, DebugNoBound, EqNoBound,
-        PartialEqNoBound,
-    };
+    use codec::{Decode, DecodeWithMemTracking, Encode, FullCodec, MaxEncodedLen};
+    use frame_support::{sp_runtime::traits::TrailingZeroInput, traits::Get, PalletId};
     use scale_info::TypeInfo;
 
     use crate::{
-        AuthorityId, Challenger, DeviceChallengeResponse, DeviceId, ExtrinsicContext, HashedUserId,
-        UserChallengeResponse,
+        Authenticator, AuthorityId, Challenger, CxOf, DeviceChallengeResponse, DeviceId,
+        UserAuthenticator, UserChallengeResponse,
     };
 
-    use super::{Auth, Dev, VerifyCredential};
+    use super::VerifyCredential;
 
-    #[derive(
-        Default,
-        CloneNoBound,
-        DebugNoBound,
-        Encode,
-        Decode,
-        DecodeWithMemTracking,
-        MaxEncodedLen,
-        TypeInfo,
-        PartialEqNoBound,
-        EqNoBound,
-    )]
-    #[scale_info(skip_type_params(A))]
-    pub struct DummyAttestation<A>(bool, Option<DeviceId>, PhantomData<A>);
+    type ChallengerOf<Dev> = <Dev as UserAuthenticator>::Challenger;
 
-    impl<A> DummyAttestation<A> {
-        pub fn new(value: bool, device_id: DeviceId) -> Self {
-            Self(value, Some(device_id), PhantomData)
+    #[derive(Encode, Decode, DecodeWithMemTracking, TypeInfo, Clone, PartialEq, Eq, Debug)]
+    #[scale_info(skip_type_params(Id))]
+    pub struct AuthorityFromPalletId<Id>(PhantomData<Id>);
+
+    impl<Id: Get<PalletId>> Get<AuthorityId> for AuthorityFromPalletId<Id> {
+        fn get() -> AuthorityId {
+            Decode::decode(&mut TrailingZeroInput::new(&Id::get().0))
+                .expect("Size of PalletId is less than 32 bytes; qed")
         }
     }
 
-    #[derive(
-        CloneNoBound,
-        DebugNoBound,
-        Encode,
-        Decode,
-        DecodeWithMemTracking,
-        MaxEncodedLen,
-        TypeInfo,
-        PartialEqNoBound,
-        EqNoBound,
-    )]
-    #[scale_info(skip_type_params(A))]
-    pub struct DummyCredential<A>(bool, HashedUserId, PhantomData<A>);
+    #[derive(Encode, Decode, DecodeWithMemTracking, TypeInfo, Clone, PartialEq, Eq, Debug)]
+    #[scale_info(skip_type_params(Dev, Att))]
+    /// Convenient auto-implementor of the Authenticator trait
+    pub struct Auth<Dev, Att>(PhantomData<(Dev, Att)>);
 
-    impl<A> DummyCredential<A> {
-        pub fn new(value: bool, user_id: HashedUserId) -> Self {
-            Self(value, user_id, PhantomData)
-        }
-    }
-
-    type DummyChallenger = u8;
-    type DummyCx = <DummyChallenger as Challenger>::Context;
-
-    parameter_types! {
-        const DummyAuthority: AuthorityId = s("dummy_authority");
-    }
-    pub const DUMMY_DEV: DeviceId = s("dummy_device");
-    pub const DUMMY_USER: HashedUserId = s("dummy_user_hash");
-
-    impl Challenger for DummyChallenger {
-        type Context = Self;
-        fn generate(cx: &Self::Context, _xtc: &impl ExtrinsicContext) -> crate::Challenge {
-            [*cx; 32]
-        }
-    }
-
-    pub type DummyDev<AuthorityId> = Dev<
-        DummyAttestation<AuthorityId>,
-        AuthorityId,
-        DummyChallenger,
-        DummyCredential<AuthorityId>,
-    >;
-    pub type Dummy<AuthorityId> = Auth<DummyDev<AuthorityId>, DummyAttestation<AuthorityId>>;
-
-    impl<A> From<DummyAttestation<A>> for DummyDev<A> {
-        fn from(value: DummyAttestation<A>) -> Self {
-            DummyDev::new(value)
-        }
-    }
-
-    impl<A> AsRef<DeviceId> for DummyAttestation<A> {
-        fn as_ref(&self) -> &DeviceId {
-            self.1.as_ref().unwrap_or(&DUMMY_DEV)
-        }
-    }
-
-    impl<A> VerifyCredential<DummyCredential<A>> for DummyAttestation<A> {
-        fn verify(&mut self, _: &DummyCredential<A>) -> Option<()> {
-            self.0.then_some(())
-        }
-    }
-
-    impl<A> DeviceChallengeResponse<DummyCx> for DummyAttestation<A>
+    impl<Dev, Att> Authenticator for Auth<Dev, Att>
     where
-        A: Get<AuthorityId> + 'static,
+        Att: DeviceChallengeResponse<CxOf<ChallengerOf<Dev>>>,
+        Dev: UserAuthenticator + From<Att>,
     {
-        fn is_valid(&self) -> bool {
-            self.0
+        type Authority = <Dev as UserAuthenticator>::Authority;
+        type Challenger = ChallengerOf<Dev>;
+        type DeviceAttestation = Att;
+        type Device = Dev;
+
+        fn unpack_device(attestation: Self::DeviceAttestation) -> Self::Device {
+            attestation.into()
+        }
+    }
+
+    /// Convenient auto-implementor of the UserAuthenticator trait
+    #[derive(Encode, Decode, DecodeWithMemTracking, TypeInfo, Clone, PartialEq, Eq, Debug)]
+    #[scale_info(skip_type_params(A, Ch, Cred))]
+    pub struct Dev<T, A, Ch, Cred>(T, PhantomData<(A, Ch, Cred)>);
+
+    impl<T, A, Ch, Cred> Dev<T, A, Ch, Cred> {
+        pub fn new(t: T) -> Self {
+            Self(t, PhantomData)
+        }
+    }
+
+    impl<T, A, Ch, Cred> UserAuthenticator for Dev<T, A, Ch, Cred>
+    where
+        T: VerifyCredential<Cred>
+            + AsRef<DeviceId>
+            + FullCodec
+            + MaxEncodedLen
+            + TypeInfo
+            + 'static,
+        A: Get<AuthorityId> + 'static,
+        Ch: Challenger + 'static,
+        Cred: UserChallengeResponse<Ch::Context> + 'static + Send + Sync,
+    {
+        type Authority = A;
+        type Challenger = Ch;
+        type Credential = Cred;
+
+        fn verify_credential(&mut self, credential: &Self::Credential) -> Option<()> {
+            self.0.verify(credential)
         }
 
-        fn used_challenge(&self) -> (DummyCx, crate::Challenge) {
-            (0, [0; 32])
-        }
-        fn authority(&self) -> AuthorityId {
-            A::get()
-        }
         fn device_id(&self) -> &DeviceId {
-            self.1.as_ref().unwrap_or(&DUMMY_DEV)
+            self.0.as_ref()
         }
     }
 
-    impl<A> UserChallengeResponse<DummyCx> for DummyCredential<A>
-    where
-        A: Get<AuthorityId> + 'static,
-    {
-        fn is_valid(&self) -> bool {
-            self.0
+    impl<T: MaxEncodedLen, A, Ch, Cr> MaxEncodedLen for Dev<T, A, Ch, Cr> {
+        fn max_encoded_len() -> usize {
+            T::max_encoded_len()
+        }
+    }
+
+    pub mod dummy {
+        use super::*;
+        use frame_support::{
+            parameter_types, sp_runtime::str_array as s, CloneNoBound, DebugNoBound, EqNoBound,
+            PartialEqNoBound,
+        };
+        use scale_info::TypeInfo;
+
+        use crate::{
+            AuthorityId, Challenger, DeviceChallengeResponse, DeviceId, ExtrinsicContext,
+            HashedUserId, UserChallengeResponse,
+        };
+
+        use super::{Auth, Dev, VerifyCredential};
+
+        #[derive(
+            Default,
+            CloneNoBound,
+            DebugNoBound,
+            Encode,
+            Decode,
+            DecodeWithMemTracking,
+            MaxEncodedLen,
+            TypeInfo,
+            PartialEqNoBound,
+            EqNoBound,
+        )]
+        #[scale_info(skip_type_params(A))]
+        pub struct DummyAttestation<A>(bool, Option<DeviceId>, PhantomData<A>);
+
+        impl<A> DummyAttestation<A> {
+            pub fn new(value: bool, device_id: DeviceId) -> Self {
+                Self(value, Some(device_id), PhantomData)
+            }
         }
 
-        fn used_challenge(&self) -> (DummyCx, crate::Challenge) {
-            (0, [0; 32])
+        #[derive(
+            CloneNoBound,
+            DebugNoBound,
+            Encode,
+            Decode,
+            DecodeWithMemTracking,
+            MaxEncodedLen,
+            TypeInfo,
+            PartialEqNoBound,
+            EqNoBound,
+        )]
+        #[scale_info(skip_type_params(A))]
+        pub struct DummyCredential<A>(bool, HashedUserId, PhantomData<A>);
+
+        impl<A> DummyCredential<A> {
+            pub fn new(value: bool, user_id: HashedUserId) -> Self {
+                Self(value, user_id, PhantomData)
+            }
         }
 
-        fn authority(&self) -> AuthorityId {
-            A::get()
+        type DummyChallenger = u8;
+        type DummyCx = <DummyChallenger as Challenger>::Context;
+
+        parameter_types! {
+            const DummyAuthority: AuthorityId = s("dummy_authority");
+        }
+        pub const DUMMY_DEV: DeviceId = s("dummy_device");
+        pub const DUMMY_USER: HashedUserId = s("dummy_user_hash");
+
+        impl Challenger for DummyChallenger {
+            type Context = Self;
+            fn generate(cx: &Self::Context, _xtc: &impl ExtrinsicContext) -> crate::Challenge {
+                [*cx; 32]
+            }
         }
 
-        fn user_id(&self) -> HashedUserId {
-            self.1
+        pub type DummyDev<AuthorityId> = Dev<
+            DummyAttestation<AuthorityId>,
+            AuthorityId,
+            DummyChallenger,
+            DummyCredential<AuthorityId>,
+        >;
+        pub type Dummy<AuthorityId> = Auth<DummyDev<AuthorityId>, DummyAttestation<AuthorityId>>;
+
+        impl<A> From<DummyAttestation<A>> for DummyDev<A> {
+            fn from(value: DummyAttestation<A>) -> Self {
+                DummyDev::new(value)
+            }
+        }
+
+        impl<A> AsRef<DeviceId> for DummyAttestation<A> {
+            fn as_ref(&self) -> &DeviceId {
+                self.1.as_ref().unwrap_or(&DUMMY_DEV)
+            }
+        }
+
+        impl<A> VerifyCredential<DummyCredential<A>> for DummyAttestation<A> {
+            fn verify(&mut self, _: &DummyCredential<A>) -> Option<()> {
+                self.0.then_some(())
+            }
+        }
+
+        impl<A> DeviceChallengeResponse<DummyCx> for DummyAttestation<A>
+        where
+            A: Get<AuthorityId> + 'static,
+        {
+            fn is_valid(&self) -> bool {
+                self.0
+            }
+
+            fn used_challenge(&self) -> (DummyCx, crate::Challenge) {
+                (0, [0; 32])
+            }
+            fn authority(&self) -> AuthorityId {
+                A::get()
+            }
+            fn device_id(&self) -> &DeviceId {
+                self.1.as_ref().unwrap_or(&DUMMY_DEV)
+            }
+        }
+
+        impl<A> UserChallengeResponse<DummyCx> for DummyCredential<A>
+        where
+            A: Get<AuthorityId> + 'static,
+        {
+            fn is_valid(&self) -> bool {
+                self.0
+            }
+
+            fn used_challenge(&self) -> (DummyCx, crate::Challenge) {
+                (0, [0; 32])
+            }
+
+            fn authority(&self) -> AuthorityId {
+                A::get()
+            }
+
+            fn user_id(&self) -> HashedUserId {
+                self.1
+            }
         }
     }
 }
+
+#[cfg(feature = "runtime")]
+pub use runtime::*;


### PR DESCRIPTION
## Summary
- Makes `frame-support` an optional dependency of `fc-traits-authn`, gated behind a new `runtime` feature (enabled by default).
- Allows non-FRAME consumers (e.g. client-side / wasm code) to depend on the crate for just `Challenge`, `DeviceId`, `HashedUserId`, `ExtrinsicContext`, and `VerifyCredential` without pulling in FRAME.
- Downstream crates (`fc-pallet-pass`, `traits/`) now opt in explicitly via `features = ["runtime"]`; no behavioral change for existing consumers.

## Test plan
- [x] `cargo check -p fc-traits-authn` (default features)
- [x] `cargo check -p fc-traits-authn --no-default-features --features std` (runtime disabled)
- [x] `cargo check -p fc-pallet-pass`