### PR TITLE
feat(pallet-communities): private communities with merkle membership proofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1142,6 +1142,7 @@ dependencies = [
 name = "fc-pallet-communities"
 version = "1.0.0"
 dependencies = [
+ "binary-merkle-tree",
  "fc-pallet-referenda-tracks",
  "frame-benchmarking",
  "frame-contrib-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1144,6 +1144,7 @@ version = "1.0.0"
 dependencies = [
  "binary-merkle-tree",
  "fc-pallet-referenda-tracks",
+ "fc-traits-proof-verifier",
  "frame-benchmarking",
  "frame-contrib-traits",
  "frame-support",
@@ -1377,6 +1378,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fc-traits-proof-verifier"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+]
+
+[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,6 +1493,7 @@ dependencies = [
  "fc-traits-listings",
  "fc-traits-memberships",
  "fc-traits-payments",
+ "fc-traits-proof-verifier",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ fc-traits-listings = { path = "./traits/listings", default-features = false }
 fc-traits-memberships = { path = "./traits/memberships", default-features = false }
 fc-traits-nonfungibles-helpers = { path = "./traits/nonfungibles-helpers", default-features = false }
 fc-traits-payments = { path = "./traits/payments", default-features = false }
+fc-traits-proof-verifier = { path = "./traits/proof-verifier", default-features = false }
 fc-pallet-listings = { path = "./pallets/listings", default-features = false }
 fc-pallet-payments = { path = "./pallets/payments", default-features = false }
 fc-pallet-referenda-tracks = { path = "./pallets/referenda-tracks", default-features = false }
@@ -67,4 +68,5 @@ members = [
   "traits/memberships",
   "traits/nonfungibles-helpers",
   "traits/payments",
+  "traits/proof-verifier",
 ]

--- a/pallets/communities/Cargo.toml
+++ b/pallets/communities/Cargo.toml
@@ -22,6 +22,7 @@ log.workspace = true
 scale-info = { workspace = true, features = ["derive"] }
 serde = { optional = true, features = ["alloc", "derive"], workspace = true }
 sp-core.workspace = true
+sp-io.workspace = true
 sp-runtime.workspace = true
 xcm = { workspace = true, optional = true }
 

--- a/pallets/communities/Cargo.toml
+++ b/pallets/communities/Cargo.toml
@@ -11,6 +11,7 @@ version = "1.0.0"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+binary-merkle-tree = { version = "16.1.1", default-features = false }
 codec = { workspace = true, features = ["derive"] }
 frame-benchmarking = { workspace = true, optional = true }
 frame-contrib-traits.workspace = true
@@ -19,6 +20,7 @@ frame-system.workspace = true
 log.workspace = true
 scale-info = { workspace = true, features = ["derive"] }
 serde = { optional = true, features = ["alloc", "derive"], workspace = true }
+sp-core.workspace = true
 sp-runtime.workspace = true
 xcm = { workspace = true, optional = true }
 
@@ -38,6 +40,7 @@ pallet-scheduler.workspace = true
 default = ["std", "xcm", "serde"]
 serde = ["dep:serde", "scale-info/serde"]
 std = [
+  "binary-merkle-tree/std",
   "fc-pallet-referenda-tracks/std",
   "frame-benchmarking?/std",
   "frame-contrib-traits/std",

--- a/pallets/communities/Cargo.toml
+++ b/pallets/communities/Cargo.toml
@@ -14,6 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 binary-merkle-tree = { version = "16.1.1", default-features = false }
 codec = { workspace = true, features = ["derive"] }
 frame-benchmarking = { workspace = true, optional = true }
+fc-traits-proof-verifier.workspace = true
 frame-contrib-traits.workspace = true
 frame-support.workspace = true
 frame-system.workspace = true
@@ -41,6 +42,7 @@ default = ["std", "xcm", "serde"]
 serde = ["dep:serde", "scale-info/serde"]
 std = [
   "binary-merkle-tree/std",
+  "fc-traits-proof-verifier/std",
   "fc-pallet-referenda-tracks/std",
   "frame-benchmarking?/std",
   "frame-contrib-traits/std",

--- a/pallets/communities/src/extensions.rs
+++ b/pallets/communities/src/extensions.rs
@@ -1,0 +1,187 @@
+extern crate alloc;
+
+use crate::{
+    origin::RawOrigin as CommunityOrigin, Config, MerkleRoot, SubRoots, UsedNullifiers,
+};
+use codec::{Decode, DecodeWithMemTracking, Encode};
+use frame_contrib_traits::memberships::GenericRank;
+use frame_support::{
+    pallet_prelude::{TransactionValidityError, Weight},
+    CloneNoBound, DebugNoBound, DefaultNoBound, EqNoBound, PartialEqNoBound,
+};
+use frame_system::pallet_prelude::RuntimeCallFor;
+use scale_info::TypeInfo;
+use sp_core::H256;
+use sp_runtime::{
+    traits::{
+        DispatchInfoOf, DispatchOriginOf, Implication, PostDispatchInfoOf, TransactionExtension,
+        ValidateResult,
+    },
+    transaction_validity::{InvalidTransaction, TransactionSource, ValidTransaction},
+    DispatchResult,
+};
+
+/// Transaction extension that validates anonymous membership proofs.
+///
+/// When `Some(params)`, it verifies a merkle proof against the community's
+/// membership root, checks the nullifier hasn't been used, and replaces
+/// the origin with an anonymous community origin.
+///
+/// When `None`, it acts as a passthrough.
+#[derive(
+    DefaultNoBound,
+    Encode,
+    Decode,
+    DecodeWithMemTracking,
+    CloneNoBound,
+    EqNoBound,
+    PartialEqNoBound,
+    DebugNoBound,
+    TypeInfo,
+)]
+#[scale_info(skip_type_params(T))]
+pub struct AnonymousMembership<T: Config>(pub Option<MembershipProofParams<T>>);
+
+#[derive(
+    Encode,
+    Decode,
+    DecodeWithMemTracking,
+    CloneNoBound,
+    EqNoBound,
+    PartialEqNoBound,
+    DebugNoBound,
+    TypeInfo,
+)]
+#[scale_info(skip_type_params(T))]
+pub struct MembershipProofParams<T: Config> {
+    pub community_id: T::CommunityId,
+    /// The leaf hash that the prover claims is in the tree
+    pub leaf: <T::Hasher as sp_runtime::traits::Hash>::Output,
+    /// Merkle proof siblings
+    pub proof: alloc::vec::Vec<<T::Hasher as sp_runtime::traits::Hash>::Output>,
+    /// Index of the leaf in the tree
+    pub leaf_index: u32,
+    /// Total number of leaves
+    pub leaf_count: u32,
+    /// Rank exposed as public input (for vote weight)
+    pub rank: GenericRank,
+    /// Nullifier: hash(identity_secret, action_scope) -- prevents double-action
+    pub nullifier: H256,
+    /// What this proof is for (e.g. hash of poll_index for voting)
+    pub action_scope: H256,
+    /// Optional sub-track to verify against SubRoots instead of MerkleRoot
+    pub sub_track: Option<u16>,
+}
+
+impl<T: Config> TransactionExtension<RuntimeCallFor<T>> for AnonymousMembership<T>
+where
+    T::RuntimeOrigin: From<CommunityOrigin<T>>,
+    T::CommunityId: Send + Sync,
+    <T::Hasher as sp_runtime::traits::Hash>::Output: Send + Sync,
+{
+    const IDENTIFIER: &'static str = "AnonymousMembership";
+    type Implicit = ();
+    /// (community_id, nullifier) if authenticated
+    type Val = Option<(T::CommunityId, H256)>;
+    /// (community_id, action_scope, nullifier) for post-dispatch cleanup
+    type Pre = Option<(T::CommunityId, H256, H256)>;
+
+    fn weight(&self, _call: &RuntimeCallFor<T>) -> Weight {
+        // Merkle proof verification weight -- depends on proof length.
+        // For MVP, use a placeholder.
+        Weight::from_parts(50_000_000, 0)
+    }
+
+    fn validate(
+        &self,
+        origin: DispatchOriginOf<RuntimeCallFor<T>>,
+        _call: &RuntimeCallFor<T>,
+        _info: &DispatchInfoOf<RuntimeCallFor<T>>,
+        _len: usize,
+        _self_implicit: Self::Implicit,
+        _inherited_implication: &impl Implication,
+        _source: TransactionSource,
+    ) -> ValidateResult<Self::Val, RuntimeCallFor<T>> {
+        if let Some(params) = &self.0 {
+            // Get the root to verify against
+            let root = if let Some(sub_track) = params.sub_track {
+                SubRoots::<T>::get(&params.community_id, sub_track)
+            } else {
+                MerkleRoot::<T>::get(&params.community_id)
+            }
+            .ok_or(TransactionValidityError::from(InvalidTransaction::Custom(
+                1,
+            )))?; // no root set
+
+            // Verify merkle proof.
+            // The tree was built with `binary_merkle_tree::merkle_root` which
+            // hashes each item via `Hasher::hash(item.as_ref())`, so we pass
+            // the leaf as a byte-slice reference so verify_proof hashes it the
+            // same way.
+            let valid = binary_merkle_tree::verify_proof::<T::Hasher, _, _>(
+                &root,
+                params.proof.clone(),
+                params.leaf_count,
+                params.leaf_index,
+                &params.leaf,
+            );
+            if !valid {
+                return Err(InvalidTransaction::BadSigner.into());
+            }
+
+            // Check nullifier hasn't been used
+            if UsedNullifiers::<T>::contains_key((
+                &params.community_id,
+                &params.action_scope,
+                &params.nullifier,
+            )) {
+                return Err(InvalidTransaction::Stale.into());
+            }
+
+            // Create anonymous community origin
+            let mut community_origin = CommunityOrigin::new(params.community_id);
+            community_origin.with_subset(crate::origin::Subset::AnonymousMember {
+                rank: params.rank,
+                nullifier: params.nullifier,
+            });
+            let new_origin: T::RuntimeOrigin = community_origin.into();
+
+            Ok((
+                ValidTransaction::default(),
+                Some((params.community_id, params.nullifier)),
+                new_origin,
+            ))
+        } else {
+            // No proof provided, pass origin through unchanged
+            Ok((ValidTransaction::default(), None, origin))
+        }
+    }
+
+    fn prepare(
+        self,
+        val: Self::Val,
+        _origin: &DispatchOriginOf<RuntimeCallFor<T>>,
+        _call: &RuntimeCallFor<T>,
+        _info: &DispatchInfoOf<RuntimeCallFor<T>>,
+        _len: usize,
+    ) -> Result<Self::Pre, TransactionValidityError> {
+        Ok(val.map(|(cid, nullifier)| {
+            let action_scope = self.0.as_ref().map(|p| p.action_scope).unwrap_or_default();
+            (cid, action_scope, nullifier)
+        }))
+    }
+
+    fn post_dispatch_details(
+        pre: Self::Pre,
+        _info: &DispatchInfoOf<RuntimeCallFor<T>>,
+        _post_info: &PostDispatchInfoOf<RuntimeCallFor<T>>,
+        _len: usize,
+        _result: &DispatchResult,
+    ) -> Result<Weight, TransactionValidityError> {
+        // Store nullifier AFTER dispatch (whether success or failure) to prevent replay
+        if let Some((community_id, action_scope, nullifier)) = pre {
+            UsedNullifiers::<T>::insert((&community_id, &action_scope, &nullifier), ());
+        }
+        Ok(Weight::zero())
+    }
+}

--- a/pallets/communities/src/extensions.rs
+++ b/pallets/communities/src/extensions.rs
@@ -1,8 +1,10 @@
 extern crate alloc;
 
 use crate::{
-    origin::RawOrigin as CommunityOrigin, Config, MerkleRoot, SubRoots, UsedNullifiers,
+    origin::RawOrigin as CommunityOrigin, verifier::MembershipInputs, Config, MerkleRoot, SubRoots,
+    UsedNullifiers,
 };
+use fc_traits_proof_verifier::ProofVerifier;
 use codec::{Decode, DecodeWithMemTracking, Encode};
 use frame_contrib_traits::memberships::GenericRank;
 use frame_support::{
@@ -55,14 +57,8 @@ pub struct AnonymousMembership<T: Config>(pub Option<MembershipProofParams<T>>);
 #[scale_info(skip_type_params(T))]
 pub struct MembershipProofParams<T: Config> {
     pub community_id: T::CommunityId,
-    /// The leaf hash that the prover claims is in the tree
-    pub leaf: <T::Hasher as sp_runtime::traits::Hash>::Output,
-    /// Merkle proof siblings
-    pub proof: alloc::vec::Vec<<T::Hasher as sp_runtime::traits::Hash>::Output>,
-    /// Index of the leaf in the tree
-    pub leaf_index: u32,
-    /// Total number of leaves
-    pub leaf_count: u32,
+    /// The proof in whatever format the verifier expects
+    pub proof: <T::MembershipVerifier as ProofVerifier>::Proof,
     /// Rank exposed as public input (for vote weight)
     pub rank: GenericRank,
     /// Nullifier: hash(identity_secret, action_scope) -- prevents double-action
@@ -78,6 +74,7 @@ where
     T::RuntimeOrigin: From<CommunityOrigin<T>>,
     T::CommunityId: Send + Sync,
     <T::Hasher as sp_runtime::traits::Hash>::Output: Send + Sync,
+    <T::MembershipVerifier as ProofVerifier>::Proof: Send + Sync,
 {
     const IDENTIFIER: &'static str = "AnonymousMembership";
     type Implicit = ();
@@ -113,21 +110,10 @@ where
                 1,
             )))?; // no root set
 
-            // Verify merkle proof.
-            // The tree was built with `binary_merkle_tree::merkle_root` which
-            // hashes each item via `Hasher::hash(item.as_ref())`, so we pass
-            // the leaf as a byte-slice reference so verify_proof hashes it the
-            // same way.
-            let valid = binary_merkle_tree::verify_proof::<T::Hasher, _, _>(
-                &root,
-                params.proof.clone(),
-                params.leaf_count,
-                params.leaf_index,
-                &params.leaf,
-            );
-            if !valid {
-                return Err(InvalidTransaction::BadSigner.into());
-            }
+            // Verify proof via the configured verifier
+            let public_inputs = MembershipInputs { root };
+            T::MembershipVerifier::verify(&(), &params.proof, &public_inputs)
+                .map_err(|_| TransactionValidityError::from(InvalidTransaction::BadSigner))?;
 
             // Check nullifier hasn't been used
             if UsedNullifiers::<T>::contains_key((

--- a/pallets/communities/src/extensions.rs
+++ b/pallets/communities/src/extensions.rs
@@ -4,9 +4,8 @@ use crate::{
     origin::RawOrigin as CommunityOrigin, verifier::MembershipInputs, Config, MerkleRoot, SubRoots,
     UsedNullifiers,
 };
-use fc_traits_proof_verifier::ProofVerifier;
 use codec::{Decode, DecodeWithMemTracking, Encode};
-use frame_contrib_traits::memberships::GenericRank;
+use fc_traits_proof_verifier::ProofVerifier;
 use frame_support::{
     pallet_prelude::{TransactionValidityError, Weight},
     CloneNoBound, DebugNoBound, DefaultNoBound, EqNoBound, PartialEqNoBound,
@@ -23,13 +22,37 @@ use sp_runtime::{
     DispatchResult,
 };
 
-/// Transaction extension that validates anonymous membership proofs.
+/// Custom transaction validity codes for this extension.
+pub mod codes {
+    /// The community has no membership root to verify against.
+    pub const NO_MEMBERSHIP_ROOT: u8 = 100;
+    /// The proof did not verify against the membership root.
+    pub const INVALID_MEMBERSHIP_PROOF: u8 = 101;
+    /// The nullifier has already been consumed for this action scope.
+    pub const NULLIFIER_USED: u8 = 102;
+}
+
+/// Transaction extension that authenticates anonymous community members.
 ///
-/// When `Some(params)`, it verifies a merkle proof against the community's
-/// membership root, checks the nullifier hasn't been used, and replaces
-/// the origin with an anonymous community origin.
+/// When `Some(params)`, it verifies a merkle inclusion proof against the community's
+/// root and replaces the origin with an anonymous community origin. The nullifier
+/// stored in `UsedNullifiers` is **derived deterministically** from the proof leaf
+/// and the call hash, so a single leaf cannot authorize more than one action per
+/// call scope. Callers cannot pick their own nullifier or rank — both are derived
+/// on-chain.
 ///
 /// When `None`, it acts as a passthrough.
+///
+/// ### Soundness limits of the merkle-only MVP
+///
+/// The verifier only proves leaf membership, not leaf *contents*. Therefore:
+/// - The pallet cannot trust any claimed rank carried in the proof; anonymous votes
+///   are rank-1 regardless of the leaf's actual rank.
+/// - Anonymity is pseudonymity: the leaf is public, so on-chain observers can link a
+///   vote to a member. Real privacy requires the ZK verifier backend.
+///
+/// These limits are lifted once `MembershipVerifier` is replaced with a ZK proof
+/// verifier that binds private inputs (rank, nullifier seed) to the leaf.
 #[derive(
     DefaultNoBound,
     Encode,
@@ -59,12 +82,6 @@ pub struct MembershipProofParams<T: Config> {
     pub community_id: T::CommunityId,
     /// The proof in whatever format the verifier expects
     pub proof: <T::MembershipVerifier as ProofVerifier>::Proof,
-    /// Rank exposed as public input (for vote weight)
-    pub rank: GenericRank,
-    /// Nullifier: hash(identity_secret, action_scope) -- prevents double-action
-    pub nullifier: H256,
-    /// What this proof is for (e.g. hash of poll_index for voting)
-    pub action_scope: H256,
     /// Optional sub-track to verify against SubRoots instead of MerkleRoot
     pub sub_track: Option<u16>,
 }
@@ -76,71 +93,87 @@ where
     <T::Hasher as sp_runtime::traits::Hash>::Output: Send + Sync,
     <T::MembershipVerifier as ProofVerifier>::Proof: Send + Sync,
 {
-    const IDENTIFIER: &'static str = "AnonymousMembership";
+    const IDENTIFIER: &'static str = "fc_pallet_communities::AnonymousMembership";
     type Implicit = ();
-    /// (community_id, nullifier) if authenticated
-    type Val = Option<(T::CommunityId, H256)>;
-    /// (community_id, action_scope, nullifier) for post-dispatch cleanup
+    /// (community_id, action_scope, nullifier) when authenticated. Used at dispatch and
+    /// post-dispatch time. All three are derived server-side — never trusted from the caller.
+    type Val = Option<(T::CommunityId, H256, H256)>;
     type Pre = Option<(T::CommunityId, H256, H256)>;
 
     fn weight(&self, _call: &RuntimeCallFor<T>) -> Weight {
-        // Merkle proof verification weight -- depends on proof length.
-        // For MVP, use a placeholder.
+        // Placeholder until benchmarks return. Scales with proof size in a real backend.
         Weight::from_parts(50_000_000, 0)
     }
 
     fn validate(
         &self,
         origin: DispatchOriginOf<RuntimeCallFor<T>>,
-        _call: &RuntimeCallFor<T>,
+        call: &RuntimeCallFor<T>,
         _info: &DispatchInfoOf<RuntimeCallFor<T>>,
         _len: usize,
         _self_implicit: Self::Implicit,
         _inherited_implication: &impl Implication,
         _source: TransactionSource,
     ) -> ValidateResult<Self::Val, RuntimeCallFor<T>> {
-        if let Some(params) = &self.0 {
-            // Get the root to verify against
-            let root = if let Some(sub_track) = params.sub_track {
-                SubRoots::<T>::get(&params.community_id, sub_track)
-            } else {
-                MerkleRoot::<T>::get(&params.community_id)
-            }
-            .ok_or(TransactionValidityError::from(InvalidTransaction::Custom(
-                1,
-            )))?; // no root set
+        let Some(params) = &self.0 else {
+            return Ok((ValidTransaction::default(), None, origin));
+        };
 
-            // Verify proof via the configured verifier
-            let public_inputs = MembershipInputs { root };
-            T::MembershipVerifier::verify(&(), &params.proof, &public_inputs)
-                .map_err(|_| TransactionValidityError::from(InvalidTransaction::BadSigner))?;
-
-            // Check nullifier hasn't been used
-            if UsedNullifiers::<T>::contains_key((
-                &params.community_id,
-                &params.action_scope,
-                &params.nullifier,
-            )) {
-                return Err(InvalidTransaction::Stale.into());
-            }
-
-            // Create anonymous community origin
-            let mut community_origin = CommunityOrigin::new(params.community_id);
-            community_origin.with_subset(crate::origin::Subset::AnonymousMember {
-                rank: params.rank,
-                nullifier: params.nullifier,
-            });
-            let new_origin: T::RuntimeOrigin = community_origin.into();
-
-            Ok((
-                ValidTransaction::default(),
-                Some((params.community_id, params.nullifier)),
-                new_origin,
-            ))
+        let root = if let Some(sub_track) = params.sub_track {
+            SubRoots::<T>::get(&params.community_id, sub_track)
         } else {
-            // No proof provided, pass origin through unchanged
-            Ok((ValidTransaction::default(), None, origin))
+            MerkleRoot::<T>::get(&params.community_id)
         }
+        .ok_or(TransactionValidityError::from(InvalidTransaction::Custom(
+            codes::NO_MEMBERSHIP_ROOT,
+        )))?;
+
+        let public_inputs = MembershipInputs { root };
+        T::MembershipVerifier::verify(&(), &params.proof, &public_inputs).map_err(|_| {
+            TransactionValidityError::from(InvalidTransaction::Custom(
+                codes::INVALID_MEMBERSHIP_PROOF,
+            ))
+        })?;
+
+        // Action scope is derived from the call being dispatched — the caller cannot
+        // choose it, so a proof authenticated for one call cannot be re-used for another.
+        let action_scope: H256 = sp_io::hashing::blake2_256(&call.encode()).into();
+
+        // Nullifier is derived from the verified proof leaf and the action scope. Two
+        // consequences: (a) the caller cannot pick fresh random nullifiers to bypass the
+        // replay check, and (b) the same leaf produces the same nullifier for the same
+        // call, so duplicates collide in `UsedNullifiers`.
+        let nullifier_preimage = (
+            b"fc-communities/null/v1",
+            &params.community_id,
+            action_scope.as_bytes(),
+            params.sub_track,
+            root.encode(),
+            params.proof.encode(),
+        )
+            .encode();
+        let nullifier: H256 = sp_io::hashing::blake2_256(&nullifier_preimage).into();
+
+        if UsedNullifiers::<T>::contains_key((&params.community_id, &action_scope, &nullifier)) {
+            return Err(TransactionValidityError::from(InvalidTransaction::Custom(
+                codes::NULLIFIER_USED,
+            )));
+        }
+
+        let mut community_origin = CommunityOrigin::new(params.community_id);
+        community_origin.with_subset(crate::origin::Subset::AnonymousMember {
+            // Rank cannot be trusted without a ZK binding — treat the anonymous vote as
+            // rank-1 (membership-only) regardless of the leaf's on-chain rank.
+            rank: frame_contrib_traits::memberships::GenericRank::default(),
+            nullifier,
+        });
+        let new_origin: T::RuntimeOrigin = community_origin.into();
+
+        Ok((
+            ValidTransaction::default(),
+            Some((params.community_id, action_scope, nullifier)),
+            new_origin,
+        ))
     }
 
     fn prepare(
@@ -151,10 +184,7 @@ where
         _info: &DispatchInfoOf<RuntimeCallFor<T>>,
         _len: usize,
     ) -> Result<Self::Pre, TransactionValidityError> {
-        Ok(val.map(|(cid, nullifier)| {
-            let action_scope = self.0.as_ref().map(|p| p.action_scope).unwrap_or_default();
-            (cid, action_scope, nullifier)
-        }))
+        Ok(val)
     }
 
     fn post_dispatch_details(
@@ -164,7 +194,8 @@ where
         _len: usize,
         _result: &DispatchResult,
     ) -> Result<Weight, TransactionValidityError> {
-        // Store nullifier AFTER dispatch (whether success or failure) to prevent replay
+        // Store the nullifier whether dispatch succeeded or failed — otherwise a caller
+        // could griefing-loop by crafting failing calls that never consume the nullifier.
         if let Some((community_id, action_scope, nullifier)) = pre {
             UsedNullifiers::<T>::insert((&community_id, &action_scope, &nullifier), ());
         }

--- a/pallets/communities/src/functions.rs
+++ b/pallets/communities/src/functions.rs
@@ -257,33 +257,48 @@ impl<T: Config> Pallet<T> {
         });
     }
 
-    /// Recompute and store the merkle root for public communities.
-    /// For private/hybrid communities this is a no-op (root is set manually).
+    /// Keep the stored merkle root consistent after a membership change.
+    ///
+    /// Behaviour by privacy level:
+    /// - **Public**: rebuild the root from on-chain members (authoritative source).
+    /// - **Hybrid**: clear the root. Hybrid communities mix on-chain and off-chain
+    ///   members, so an on-chain change alone cannot produce a valid tree — the admin
+    ///   must republish via `update_membership_root`. Clearing the root is the safe
+    ///   default: in-flight anonymous proofs would otherwise remain valid against an
+    ///   already-stale tree (e.g. a suspended member could continue to anonymously
+    ///   vote until the admin bothered to update).
+    /// - **Private**: clear the root for the same reason as Hybrid. Since all
+    ///   membership is off-chain, we can't rebuild, but we can *refuse* anonymous
+    ///   actions until the admin republishes.
+    ///
+    /// Clearing `MerkleRoot` causes the extension to reject proofs with
+    /// `NO_MEMBERSHIP_ROOT`, which is the desired fail-closed behaviour.
     pub fn recompute_merkle_root(community_id: &CommunityIdOf<T>) {
-        let info = match Info::<T>::get(community_id) {
-            Some(info) if info.privacy == PrivacyLevel::Public => info,
-            _ => return,
-        };
-        let _ = info; // used only for the privacy check above
-
-        let mut leaves: alloc::vec::Vec<<T::Hasher as sp_runtime::traits::Hash>::Output> =
-            Members::<T>::iter_prefix(community_id)
-                .filter(|(_, record)| record.status == MemberStatus::Active)
-                .map(|(who, record)| {
-                    T::Hasher::hash_of(&(who, community_id, record.rank, record.nonce))
-                })
-                .collect();
-
-        leaves.sort();
-
-        if leaves.is_empty() {
-            MerkleRoot::<T>::remove(community_id);
-        } else {
-            let root = binary_merkle_tree::merkle_root::<T::Hasher, _>(leaves);
-            MerkleRoot::<T>::insert(community_id, root);
+        match Info::<T>::get(community_id).map(|i| i.privacy) {
+            Some(PrivacyLevel::Public) => {
+                let mut leaves: alloc::vec::Vec<<T::Hasher as sp_runtime::traits::Hash>::Output> =
+                    Members::<T>::iter_prefix(community_id)
+                        .filter(|(_, record)| record.status == MemberStatus::Active)
+                        .map(|(who, record)| {
+                            T::Hasher::hash_of(&(who, community_id, record.rank, record.nonce))
+                        })
+                        .collect();
+                leaves.sort();
+                if leaves.is_empty() {
+                    MerkleRoot::<T>::remove(community_id);
+                } else {
+                    let root = binary_merkle_tree::merkle_root::<T::Hasher, _>(leaves);
+                    MerkleRoot::<T>::insert(community_id, root);
+                }
+            }
+            Some(PrivacyLevel::Private) | Some(PrivacyLevel::Hybrid) => {
+                // Fail-closed: an on-chain suspend/remove may have invalidated the tree.
+                // The admin must republish with `update_membership_root`.
+                MerkleRoot::<T>::remove(community_id);
+            }
+            None => {}
         }
     }
-
 }
 
 impl<T: Config> Tally<T> {

--- a/pallets/communities/src/functions.rs
+++ b/pallets/communities/src/functions.rs
@@ -11,6 +11,7 @@ use frame_support::{
     },
 };
 use sp_runtime::traits::{AccountIdConversion, Dispatchable, Hash as _};
+use sp_runtime::Saturating;
 
 impl<T: Config> Pallet<T> {
     #[inline]
@@ -226,6 +227,48 @@ impl<T: Config> Pallet<T> {
         call.dispatch(signer.into())
             .map(|_| ())
             .map_err(|e| e.error)
+    }
+
+    /// Check if community has enough budget for the given cost.
+    /// Resets session if expired. Returns remaining capacity after deduction.
+    pub fn check_budget(community_id: &CommunityIdOf<T>, cost: u64) -> Result<u64, Error<T>> {
+        let mut budget = Budget::<T>::get(community_id).ok_or(Error::<T>::BudgetExhausted)?;
+        let now = T::BlockNumberProvider::current_block_number();
+
+        // Reset session if expired
+        if now >= budget.session_start.saturating_add(budget.session_length) {
+            budget.used = 0;
+            budget.session_start = now;
+        }
+
+        let remaining = budget.capacity.saturating_sub(budget.used);
+        if remaining < cost {
+            return Err(Error::<T>::BudgetExhausted);
+        }
+        Ok(remaining.saturating_sub(cost))
+    }
+
+    /// Burn gas from community budget. Resets session if expired.
+    pub fn burn_budget(community_id: &CommunityIdOf<T>, cost: u64) {
+        Budget::<T>::mutate(community_id, |maybe_budget| {
+            if let Some(budget) = maybe_budget {
+                let now = T::BlockNumberProvider::current_block_number();
+                if now >= budget.session_start.saturating_add(budget.session_length) {
+                    budget.used = 0;
+                    budget.session_start = now;
+                }
+                budget.used = budget.used.saturating_add(cost);
+            }
+        });
+    }
+
+    /// Refund gas back to community budget.
+    pub fn refund_budget(community_id: &CommunityIdOf<T>, amount: u64) {
+        Budget::<T>::mutate(community_id, |maybe_budget| {
+            if let Some(budget) = maybe_budget {
+                budget.used = budget.used.saturating_sub(amount);
+            }
+        });
     }
 
     /// Recompute and store the merkle root for public communities.

--- a/pallets/communities/src/functions.rs
+++ b/pallets/communities/src/functions.rs
@@ -10,7 +10,7 @@ use frame_support::{
         Polling,
     },
 };
-use sp_runtime::traits::{AccountIdConversion, Dispatchable};
+use sp_runtime::traits::{AccountIdConversion, Dispatchable, Hash as _};
 
 impl<T: Config> Pallet<T> {
     #[inline]
@@ -226,6 +226,33 @@ impl<T: Config> Pallet<T> {
         call.dispatch(signer.into())
             .map(|_| ())
             .map_err(|e| e.error)
+    }
+
+    /// Recompute and store the merkle root for public communities.
+    /// For private/hybrid communities this is a no-op (root is set manually).
+    pub fn recompute_merkle_root(community_id: &CommunityIdOf<T>) {
+        let info = match Info::<T>::get(community_id) {
+            Some(info) if info.privacy == PrivacyLevel::Public => info,
+            _ => return,
+        };
+        let _ = info; // used only for the privacy check above
+
+        let mut leaves: alloc::vec::Vec<<T::Hasher as sp_runtime::traits::Hash>::Output> =
+            Members::<T>::iter_prefix(community_id)
+                .filter(|(_, record)| record.status == MemberStatus::Active)
+                .map(|(who, record)| {
+                    T::Hasher::hash_of(&(who, community_id, record.rank, record.nonce))
+                })
+                .collect();
+
+        leaves.sort();
+
+        if leaves.is_empty() {
+            MerkleRoot::<T>::remove(community_id);
+        } else {
+            let root = binary_merkle_tree::merkle_root::<T::Hasher, _>(leaves);
+            MerkleRoot::<T>::insert(community_id, root);
+        }
     }
 }
 

--- a/pallets/communities/src/functions.rs
+++ b/pallets/communities/src/functions.rs
@@ -105,7 +105,7 @@ impl<T: Config> Pallet<T> {
             };
 
             let vote_weight = VoteWeight::from(vote);
-            let multiplied = vote_multiplier * vote_weight;
+            let multiplied = vote_multiplier.saturating_mul(vote_weight);
             tally.add_vote(say, multiplied, vote_weight);
 
             CommunityVotes::<T>::insert(poll_index, voter_key, (vote, multiplied));
@@ -284,14 +284,6 @@ impl<T: Config> Pallet<T> {
         }
     }
 
-    /// Extract a community origin from a runtime origin.
-    /// Returns BadOrigin if the origin is not a community origin.
-    pub(crate) fn extract_community_origin(
-        origin: OriginFor<T>,
-    ) -> Result<origin::RawOrigin<T>, DispatchError> {
-        let raw: Result<origin::RawOrigin<T>, _> = origin.into();
-        raw.map_err(|_| DispatchError::BadOrigin)
-    }
 }
 
 impl<T: Config> Tally<T> {

--- a/pallets/communities/src/functions.rs
+++ b/pallets/communities/src/functions.rs
@@ -35,6 +35,48 @@ impl<T: Config> Pallet<T> {
             .unwrap_or_default()
     }
 
+    /// Whether `who` can act as a manager of the community: Admin and Manager roles,
+    /// active status only. Used to gate member-management extrinsics when invoked by
+    /// a signed origin that's also a community member.
+    pub fn is_member_manager(community_id: &T::CommunityId, who: &AccountIdOf<T>) -> bool {
+        match Members::<T>::get(community_id, who) {
+            Some(rec) => {
+                rec.status == MemberStatus::Active
+                    && matches!(rec.role, Role::Admin | Role::Manager)
+            }
+            None => false,
+        }
+    }
+
+    /// Resolve the community id for a member-mgmt action, and enforce that if the
+    /// caller is a *signed* account (rather than a community/root/governance origin),
+    /// that account holds the Admin or Manager role in the target community.
+    ///
+    /// This is the authorization layer that makes `Role` meaningful. Without it,
+    /// anyone who satisfies `MemberMgmtOrigin` (often `EnsureCommunity`, which accepts
+    /// the community origin or accounts registered via `CommunityIdFor`) could take
+    /// member-management actions regardless of role.
+    pub(crate) fn ensure_member_mgmt(
+        origin: OriginFor<T>,
+    ) -> Result<CommunityIdOf<T>, DispatchError> {
+        // Pull out the signed caller (if any) before handing the origin to the
+        // configured guard — the guard consumes it.
+        let maybe_signer = origin
+            .as_system_ref()
+            .and_then(|s| match s {
+                frame_system::RawOrigin::Signed(who) => Some(who.clone()),
+                _ => None,
+            });
+        let community_id = T::MemberMgmtOrigin::ensure_origin(origin)?;
+        if let Some(signer) = maybe_signer {
+            ensure!(
+                Self::is_member_manager(&community_id, &signer),
+                Error::<T>::NotAuthorized,
+            );
+        }
+        Ok(community_id)
+    }
+
     pub fn force_state(community_id: &CommunityIdOf<T>, state: CommunityState) {
         Info::<T>::mutate(community_id, |c| c.as_mut().map(|c| c.state = state));
     }

--- a/pallets/communities/src/functions.rs
+++ b/pallets/communities/src/functions.rs
@@ -10,7 +10,7 @@ use frame_support::{
         Polling,
     },
 };
-use sp_runtime::traits::{AccountIdConversion, Dispatchable, Hash as _};
+use sp_runtime::traits::{AccountIdConversion, Dispatchable};
 use sp_runtime::Saturating;
 
 impl<T: Config> Pallet<T> {
@@ -79,24 +79,17 @@ impl<T: Config> Pallet<T> {
         Ok(())
     }
 
-    pub(crate) fn try_vote(
+    pub(crate) fn try_vote_by_key(
         community_id: &CommunityIdOf<T>,
         decision_method: &DecisionMethodFor<T>,
-        who: &AccountIdOf<T>,
+        vote_multiplier: u32,
+        voter_key: &<T::Hasher as sp_runtime::traits::Hash>::Output,
         poll_index: PollIndexOf<T>,
         vote: &VoteOf<T>,
     ) -> DispatchResult {
         T::Polls::try_access_poll(poll_index, |poll_status| {
             let (tally, class) = poll_status.ensure_ongoing().ok_or(Error::<T>::NotOngoing)?;
             ensure!(community_id == &class, Error::<T>::InvalidTrack);
-
-            let vote_multiplier = match CommunityDecisionMethod::<T>::get(community_id) {
-                DecisionMethod::Rank => {
-                    let rank: u32 = Self::member_rank(community_id, who).into();
-                    rank
-                }
-                _ => 1,
-            };
 
             let say = *match (vote, decision_method) {
                 (
@@ -112,38 +105,31 @@ impl<T: Config> Pallet<T> {
             };
 
             let vote_weight = VoteWeight::from(vote);
-            tally.add_vote(say, vote_multiplier * vote_weight, vote_weight);
+            let multiplied = vote_multiplier * vote_weight;
+            tally.add_vote(say, multiplied, vote_weight);
 
-            CommunityVotes::<T>::insert(poll_index, who, (vote, who));
-            Self::update_locks(who, poll_index, vote, LockUpdateType::Add)
+            CommunityVotes::<T>::insert(poll_index, voter_key, (vote, multiplied));
+            Ok(())
         })
     }
 
-    pub(crate) fn try_remove_vote(
+    pub(crate) fn try_remove_vote_by_key(
         community_id: &CommunityIdOf<T>,
-        decision_method: &DecisionMethodFor<T>,
-        who: &AccountIdOf<T>,
+        voter_key: &<T::Hasher as sp_runtime::traits::Hash>::Output,
         poll_index: PollIndexOf<T>,
     ) -> DispatchResult {
         T::Polls::try_access_poll(poll_index, |poll_status| {
             let (tally, class) = poll_status.ensure_ongoing().ok_or(Error::<T>::NotOngoing)?;
             ensure!(community_id == &class, Error::<T>::InvalidTrack);
 
-            let (vote, voter) = CommunityVotes::<T>::get(poll_index, who)
+            let (vote, multiplied) = CommunityVotes::<T>::get(poll_index, voter_key)
                 .ok_or(Error::<T>::NoVoteCasted)?;
-            let vote_multiplier = match decision_method {
-                DecisionMethod::Rank => {
-                    let rank: u32 = Self::member_rank(community_id, who).into();
-                    rank
-                }
-                _ => 1,
-            };
 
             let vote_weight = VoteWeight::from(&vote);
-            tally.remove_vote(vote.say(), vote_multiplier * vote_weight, vote_weight);
+            tally.remove_vote(vote.say(), multiplied, vote_weight);
 
-            CommunityVotes::<T>::remove(poll_index, who);
-            Self::update_locks(&voter, poll_index, &vote, LockUpdateType::Remove)
+            CommunityVotes::<T>::remove(poll_index, voter_key);
+            Ok(())
         })
     }
 
@@ -296,6 +282,15 @@ impl<T: Config> Pallet<T> {
             let root = binary_merkle_tree::merkle_root::<T::Hasher, _>(leaves);
             MerkleRoot::<T>::insert(community_id, root);
         }
+    }
+
+    /// Extract a community origin from a runtime origin.
+    /// Returns BadOrigin if the origin is not a community origin.
+    pub(crate) fn extract_community_origin(
+        origin: OriginFor<T>,
+    ) -> Result<origin::RawOrigin<T>, DispatchError> {
+        let raw: Result<origin::RawOrigin<T>, _> = origin.into();
+        raw.map_err(|_| DispatchError::BadOrigin)
     }
 }
 

--- a/pallets/communities/src/functions.rs
+++ b/pallets/communities/src/functions.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use frame_contrib_traits::memberships::{GenericRank, Inspect, Rank};
+use frame_contrib_traits::memberships::GenericRank;
 use frame_support::{
     fail,
     traits::{
@@ -23,20 +23,15 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn is_member(community_id: &T::CommunityId, who: &AccountIdOf<T>) -> bool {
-        T::MemberMgmt::is_member_of(community_id, who)
+        Members::<T>::get(community_id, who)
+            .map(|m| m.status == MemberStatus::Active)
+            .unwrap_or(false)
     }
 
-    pub fn member_rank(community_id: &T::CommunityId, m: &MembershipIdOf<T>) -> GenericRank {
-        T::MemberMgmt::rank_of(community_id, m).unwrap_or_default()
-    }
-
-    pub fn get_memberships(
-        community_id: T::CommunityId,
-        who: &AccountIdOf<T>,
-    ) -> Vec<MembershipIdOf<T>> {
-        T::MemberMgmt::user_memberships(who, Some(community_id))
-            .map(|(_, m)| m)
-            .collect::<Vec<_>>()
+    pub fn member_rank(community_id: &T::CommunityId, who: &AccountIdOf<T>) -> GenericRank {
+        Members::<T>::get(community_id, who)
+            .map(|m| m.rank)
+            .unwrap_or_default()
     }
 
     pub fn force_state(community_id: &CommunityIdOf<T>, state: CommunityState) {
@@ -70,7 +65,14 @@ impl<T: Config> Pallet<T> {
         }
 
         CommunityIdFor::<T>::insert(admin, community_id);
-        Info::<T>::insert(community_id, CommunityInfo::default());
+        Info::<T>::insert(
+            community_id,
+            CommunityInfo {
+                state: CommunityState::default(),
+                privacy: PrivacyLevel::default(),
+                capacity: T::MaxMembers::get(),
+            },
+        );
         frame_system::Pallet::<T>::inc_providers(&Self::community_account(community_id));
 
         Ok(())
@@ -80,7 +82,6 @@ impl<T: Config> Pallet<T> {
         community_id: &CommunityIdOf<T>,
         decision_method: &DecisionMethodFor<T>,
         who: &AccountIdOf<T>,
-        membership_id: &MembershipIdOf<T>,
         poll_index: PollIndexOf<T>,
         vote: &VoteOf<T>,
     ) -> DispatchResult {
@@ -89,9 +90,10 @@ impl<T: Config> Pallet<T> {
             ensure!(community_id == &class, Error::<T>::InvalidTrack);
 
             let vote_multiplier = match CommunityDecisionMethod::<T>::get(community_id) {
-                DecisionMethod::Rank => T::MemberMgmt::rank_of(community_id, membership_id)
-                    .unwrap_or_default()
-                    .into(),
+                DecisionMethod::Rank => {
+                    let rank: u32 = Self::member_rank(community_id, who).into();
+                    rank
+                }
                 _ => 1,
             };
 
@@ -111,7 +113,7 @@ impl<T: Config> Pallet<T> {
             let vote_weight = VoteWeight::from(vote);
             tally.add_vote(say, vote_multiplier * vote_weight, vote_weight);
 
-            CommunityVotes::<T>::insert(poll_index, membership_id, (vote, who));
+            CommunityVotes::<T>::insert(poll_index, who, (vote, who));
             Self::update_locks(who, poll_index, vote, LockUpdateType::Add)
         })
     }
@@ -119,26 +121,27 @@ impl<T: Config> Pallet<T> {
     pub(crate) fn try_remove_vote(
         community_id: &CommunityIdOf<T>,
         decision_method: &DecisionMethodFor<T>,
-        membership_id: &MembershipIdOf<T>,
+        who: &AccountIdOf<T>,
         poll_index: PollIndexOf<T>,
     ) -> DispatchResult {
         T::Polls::try_access_poll(poll_index, |poll_status| {
             let (tally, class) = poll_status.ensure_ongoing().ok_or(Error::<T>::NotOngoing)?;
             ensure!(community_id == &class, Error::<T>::InvalidTrack);
 
-            let (vote, voter) = CommunityVotes::<T>::get(poll_index, membership_id)
+            let (vote, voter) = CommunityVotes::<T>::get(poll_index, who)
                 .ok_or(Error::<T>::NoVoteCasted)?;
             let vote_multiplier = match decision_method {
-                DecisionMethod::Rank => T::MemberMgmt::rank_of(community_id, membership_id)
-                    .unwrap_or_default()
-                    .into(),
+                DecisionMethod::Rank => {
+                    let rank: u32 = Self::member_rank(community_id, who).into();
+                    rank
+                }
                 _ => 1,
             };
 
             let vote_weight = VoteWeight::from(&vote);
             tally.remove_vote(vote.say(), vote_multiplier * vote_weight, vote_weight);
 
-            CommunityVotes::<T>::remove(poll_index, membership_id);
+            CommunityVotes::<T>::remove(poll_index, who);
             Self::update_locks(&voter, poll_index, &vote, LockUpdateType::Remove)
         })
     }

--- a/pallets/communities/src/impls.rs
+++ b/pallets/communities/src/impls.rs
@@ -16,11 +16,14 @@ impl<T: Config> VoteTally<VoteWeight, CommunityIdOf<T>> for Tally<T> {
     }
 
     fn support(&self, community_id: CommunityIdOf<T>) -> sp_runtime::Perbill {
-        Perbill::from_rational(self.bare_ayes, Self::max_support(community_id))
+        // `1.max(..)` guards against empty/uninitialized communities: without it
+        // `Perbill::from_rational(any_votes, 0)` clamps to 100% and any poll trivially
+        // passes the support threshold.
+        Perbill::from_rational(self.bare_ayes, 1.max(Self::max_support(community_id)))
     }
 
     fn approval(&self, _cid: CommunityIdOf<T>) -> sp_runtime::Perbill {
-        Perbill::from_rational(self.ayes, 1.max(self.ayes + self.nays))
+        Perbill::from_rational(self.ayes, 1.max(self.ayes.saturating_add(self.nays)))
     }
 
     #[cfg(feature = "runtime-benchmarks")]

--- a/pallets/communities/src/lib.rs
+++ b/pallets/communities/src/lib.rs
@@ -338,9 +338,24 @@ pub mod pallet {
         (),
     >;
 
-    /// Number of members in a community
+    /// Number of members in a community. For Public communities this is maintained
+    /// automatically by add/remove/suspend. For Private/Hybrid communities this counts
+    /// on-chain members only (may be 0); the tally denominator is taken from
+    /// [`ClaimedSupport`] instead.
     #[pallet::storage]
     pub type MemberCount<T: Config> =
+        StorageMap<_, Blake2_128Concat, CommunityIdOf<T>, u32, ValueQuery>;
+
+    /// Declared tally support for Private/Hybrid communities where membership is off-chain.
+    /// Used only as the denominator for `Polling::support()` when the community isn't
+    /// Public. Separate from [`MemberCount`] so that updating the merkle root does not
+    /// let the admin manipulate `MemberCount`-driven invariants.
+    ///
+    /// Safety note: the admin can still manipulate referendum thresholds by changing
+    /// this value — that's inherent to off-chain membership. Runtimes that want harder
+    /// guarantees should gate updates behind governance.
+    #[pallet::storage]
+    pub type ClaimedSupport<T: Config> =
         StorageMap<_, Blake2_128Concat, CommunityIdOf<T>, u32, ValueQuery>;
 
     /// Total of all member ranks in a community (for rank-weighted voting)
@@ -673,12 +688,15 @@ pub mod pallet {
             Ok(())
         }
 
-        /// Manually update the membership merkle root for private/hybrid communities
+        /// Manually update the membership merkle root and claimed support for
+        /// private/hybrid communities. `claimed_support` is written to
+        /// [`ClaimedSupport`] and is used only as the denominator for the poll-support
+        /// calculation; it does not affect [`MemberCount`] or any other on-chain invariant.
         #[pallet::call_index(13)]
         pub fn update_membership_root(
             origin: OriginFor<T>,
             new_root: <T::Hasher as sp_runtime::traits::Hash>::Output,
-            member_count: u32,
+            claimed_support: u32,
         ) -> DispatchResult {
             let community_id = T::AdminOrigin::ensure_origin(origin)?;
 
@@ -689,7 +707,7 @@ pub mod pallet {
             );
 
             MerkleRoot::<T>::insert(&community_id, new_root);
-            MemberCount::<T>::insert(&community_id, member_count);
+            ClaimedSupport::<T>::insert(&community_id, claimed_support);
 
             Self::deposit_event(Event::MembershipRootUpdated { community_id });
             Ok(())

--- a/pallets/communities/src/lib.rs
+++ b/pallets/communities/src/lib.rs
@@ -150,6 +150,7 @@ pub use weights::*;
 pub mod origin;
 
 pub mod extensions;
+pub mod verifier;
 
 #[frame_support::pallet]
 pub mod pallet {
@@ -199,6 +200,13 @@ pub mod pallet {
 
         /// The hashing algorithm used for merkle trees
         type Hasher: sp_runtime::traits::Hash;
+
+        /// Verifier for membership proofs. Use `verifier::MerkleVerifier<Self::Hasher>`
+        /// for simple merkle proofs, or a ZK verifier for privacy.
+        type MembershipVerifier: fc_traits_proof_verifier::ProofVerifier<
+            ProgramId = (),
+            PublicInputs = verifier::MembershipInputs<Self::Hasher>,
+        >;
 
         /// Maximum number of members a community can have
         type MaxMembers: Get<u32>;

--- a/pallets/communities/src/lib.rs
+++ b/pallets/communities/src/lib.rs
@@ -130,10 +130,10 @@ use sp_runtime::traits::{BlockNumberProvider, StaticLookup};
 // #[cfg(feature = "runtime-benchmarks")]
 // mod benchmarking;
 
-// #[cfg(test)]
-// mod mock;
-// #[cfg(test)]
-// mod tests;
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
 
 mod functions;
 mod impls;
@@ -361,9 +361,19 @@ pub mod pallet {
         MemberRemoved {
             who: AccountIdOf<T>,
         },
+        MemberSuspended {
+            who: AccountIdOf<T>,
+        },
         MemberRankUpdated {
             who: AccountIdOf<T>,
             rank: GenericRank,
+        },
+        MembershipRootUpdated {
+            community_id: CommunityIdOf<T>,
+        },
+        SubRootUpdated {
+            community_id: CommunityIdOf<T>,
+            sub_track_id: u16,
         },
         VoteCasted {
             who: AccountIdOf<T>,
@@ -410,6 +420,12 @@ pub mod pallet {
         AlreadyAdmin,
         /// The vote is below the minimum requried
         VoteBelowMinimum,
+        /// Cannot add members directly to a private community
+        CommunityIsPrivate,
+        /// Cannot update membership root for a public community
+        CommunityIsPublic,
+        /// The member is suspended
+        MemberIsSuspended,
     }
 
     // Dispatchable functions allows users to interact with the pallet and invoke
@@ -463,7 +479,12 @@ pub mod pallet {
 
         /// Enroll an account as a community member.
         #[pallet::call_index(3)]
-        pub fn add_member(origin: OriginFor<T>, who: AccountIdLookupOf<T>) -> DispatchResult {
+        pub fn add_member(
+            origin: OriginFor<T>,
+            who: AccountIdLookupOf<T>,
+            rank: Option<GenericRank>,
+            role: Option<Role>,
+        ) -> DispatchResult {
             let community_id = T::MemberMgmtOrigin::ensure_origin(origin)?;
             let who = T::Lookup::lookup(who)?;
 
@@ -471,6 +492,10 @@ pub mod pallet {
             ensure!(
                 info.state == CommunityState::Active,
                 Error::<T>::CommunityDoesNotExist
+            );
+            ensure!(
+                info.privacy != PrivacyLevel::Private,
+                Error::<T>::CommunityIsPrivate
             );
             ensure!(
                 !Members::<T>::contains_key(&community_id, &who),
@@ -485,9 +510,25 @@ pub mod pallet {
             };
             ensure!(count < max, Error::<T>::CommunityAtCapacity);
 
-            Members::<T>::insert(&community_id, &who, MemberRecord::default());
-            MemberCount::<T>::mutate(&community_id, |c| *c = c.saturating_add(1));
+            let member_rank = rank.unwrap_or_default();
+            let member_role = role.unwrap_or_default();
+            let rank_val: u32 = member_rank.into();
 
+            Members::<T>::insert(
+                &community_id,
+                &who,
+                MemberRecord {
+                    rank: member_rank,
+                    role: member_role,
+                    ..Default::default()
+                },
+            );
+            MemberCount::<T>::mutate(&community_id, |c| *c = c.saturating_add(1));
+            if rank_val > 0 {
+                RanksTotal::<T>::mutate(&community_id, |t| *t = t.saturating_add(rank_val));
+            }
+
+            Self::recompute_merkle_root(&community_id);
             Self::deposit_event(Event::MemberAdded { who });
             Ok(())
         }
@@ -511,6 +552,7 @@ pub mod pallet {
                 RanksTotal::<T>::mutate(&community_id, |t| *t = t.saturating_sub(rank_val));
             }
 
+            Self::recompute_merkle_root(&community_id);
             Self::deposit_event(Event::MemberRemoved { who });
             Ok(())
         }
@@ -534,6 +576,7 @@ pub mod pallet {
                 *t = t.saturating_sub(old_rank_val).saturating_add(new_rank_val);
             });
 
+            Self::recompute_merkle_root(&community_id);
             Self::deposit_event(Event::MemberRankUpdated {
                 who,
                 rank: new_rank,
@@ -560,9 +603,76 @@ pub mod pallet {
                 *t = t.saturating_sub(old_rank_val).saturating_add(new_rank_val);
             });
 
+            Self::recompute_merkle_root(&community_id);
             Self::deposit_event(Event::MemberRankUpdated {
                 who,
                 rank: new_rank,
+            });
+            Ok(())
+        }
+
+        /// Suspend a community member
+        #[pallet::call_index(12)]
+        pub fn suspend_member(
+            origin: OriginFor<T>,
+            who: AccountIdLookupOf<T>,
+        ) -> DispatchResult {
+            let community_id = T::MemberMgmtOrigin::ensure_origin(origin)?;
+            let who = T::Lookup::lookup(who)?;
+
+            let mut record =
+                Members::<T>::get(&community_id, &who).ok_or(Error::<T>::NotAMember)?;
+            ensure!(
+                record.status == MemberStatus::Active,
+                Error::<T>::MemberIsSuspended
+            );
+
+            record.status = MemberStatus::Suspended;
+            record.nonce = record.nonce.saturating_add(1);
+            Members::<T>::insert(&community_id, &who, &record);
+            MemberCount::<T>::mutate(&community_id, |c| *c = c.saturating_sub(1));
+
+            Self::recompute_merkle_root(&community_id);
+            Self::deposit_event(Event::MemberSuspended { who });
+            Ok(())
+        }
+
+        /// Manually update the membership merkle root for private/hybrid communities
+        #[pallet::call_index(13)]
+        pub fn update_membership_root(
+            origin: OriginFor<T>,
+            new_root: <T::Hasher as sp_runtime::traits::Hash>::Output,
+            member_count: u32,
+        ) -> DispatchResult {
+            let community_id = T::AdminOrigin::ensure_origin(origin)?;
+
+            let info = Info::<T>::get(&community_id).ok_or(Error::<T>::CommunityDoesNotExist)?;
+            ensure!(
+                info.privacy != PrivacyLevel::Public,
+                Error::<T>::CommunityIsPublic
+            );
+
+            MerkleRoot::<T>::insert(&community_id, new_root);
+            MemberCount::<T>::insert(&community_id, member_count);
+
+            Self::deposit_event(Event::MembershipRootUpdated { community_id });
+            Ok(())
+        }
+
+        /// Update a sub-root for sharded membership trees
+        #[pallet::call_index(14)]
+        pub fn update_sub_root(
+            origin: OriginFor<T>,
+            sub_track_id: u16,
+            new_root: <T::Hasher as sp_runtime::traits::Hash>::Output,
+        ) -> DispatchResult {
+            let community_id = T::AdminOrigin::ensure_origin(origin)?;
+
+            SubRoots::<T>::insert(&community_id, sub_track_id, new_root);
+
+            Self::deposit_event(Event::SubRootUpdated {
+                community_id,
+                sub_track_id,
             });
             Ok(())
         }

--- a/pallets/communities/src/lib.rs
+++ b/pallets/communities/src/lib.rs
@@ -457,6 +457,11 @@ pub mod pallet {
         MemberIsSuspended,
         /// The community's gas budget has been exhausted
         BudgetExhausted,
+        /// The budget parameters are invalid (e.g. zero-length session).
+        InvalidBudget,
+        /// An anonymous vote has already been cast for this voter on this poll.
+        /// Anonymous votes are immutable: they cannot be changed or removed.
+        AnonymousVoteAlreadyCast,
     }
 
     // Dispatchable functions allows users to interact with the pallet and invoke
@@ -717,8 +722,12 @@ pub mod pallet {
             capacity: u64,
             session_length: BlockNumberFor<T>,
         ) -> DispatchResult {
+            use sp_runtime::traits::Zero;
             let community_id = T::AdminOrigin::ensure_origin(origin)?;
             ensure!(Self::community_exists(&community_id), Error::<T>::CommunityDoesNotExist);
+            // A zero-length session would reset the budget on every check, making the
+            // capacity cap meaningless.
+            ensure!(!session_length.is_zero(), Error::<T>::InvalidBudget);
             let now = T::BlockNumberProvider::current_block_number();
             Budget::<T>::insert(&community_id, CommunityBudget {
                 capacity,
@@ -764,7 +773,11 @@ pub mod pallet {
         ) -> DispatchResult {
             ensure!(VoteWeight::from(&vote).gt(&0), Error::<T>::VoteBelowMinimum);
 
-            // Determine voting path: signed (named) or community origin (anonymous)
+            // Determine voting path: signed (named) or community origin (anonymous).
+            // The anonymous branch goes through `EnsureAnonymousVoter`, which rejects every
+            // community-origin variant *except* `Subset::AnonymousMember`. That keeps the
+            // anonymous privilege scoped to voting only — a membership proof cannot dispatch
+            // admin or member-management calls that check `MemberMgmtOrigin`/`AdminOrigin`.
             let (community_id, voter_key, vote_multiplier, maybe_who): (
                 CommunityIdOf<T>,
                 <T::Hasher as sp_runtime::traits::Hash>::Output,
@@ -786,33 +799,30 @@ pub mod pallet {
                 let key = T::Hasher::hash_of(&who);
                 (community_id, key, multiplier, Some(who))
             } else {
-                // Anonymous vote path - try community origin
-                let community_origin = Self::extract_community_origin(origin)?;
-                match community_origin.subset() {
-                    Some(origin::Subset::AnonymousMember { rank, nullifier }) => {
-                        let community_id = community_origin.id();
-                        let decision_method = CommunityDecisionMethod::<T>::get(community_id);
-                        // Token-weighted voting not supported anonymously
-                        ensure!(
-                            matches!(decision_method, DecisionMethod::Membership | DecisionMethod::Rank),
-                            Error::<T>::InvalidVoteType
-                        );
-                        let multiplier = match decision_method {
-                            DecisionMethod::Rank => (*rank).into(),
-                            _ => 1u32,
-                        };
-                        let key = T::Hasher::hash_of(nullifier);
-                        (community_id, key, multiplier, None)
-                    },
-                    _ => return Err(DispatchError::BadOrigin),
-                }
+                // Anonymous vote path. `EnsureAnonymousVoter` both checks we have an
+                // AnonymousMember origin *and* returns the (community_id, nullifier).
+                let (community_id, nullifier) = origin::EnsureAnonymousVoter::<T>::try_origin(origin)
+                    .map_err(|_| DispatchError::BadOrigin)?;
+                let decision_method = CommunityDecisionMethod::<T>::get(community_id);
+                // Token-weighted voting cannot be authorized anonymously (no account to lock
+                // funds against), and the leaf contents — including rank — are not verified,
+                // so rank-weighted voting is also rejected. Only flat 1-per-member voting is
+                // allowed via the anonymous path until a ZK backend binds rank to the proof.
+                ensure!(
+                    matches!(decision_method, DecisionMethod::Membership),
+                    Error::<T>::InvalidVoteType
+                );
+                let key = T::Hasher::hash_of(&nullifier);
+                (community_id, key, 1u32, None)
             };
 
             let decision_method = CommunityDecisionMethod::<T>::get(community_id);
 
-            // Check for existing vote and remove it (only for named voters)
+            // Named voters may replace their vote; anonymous voters cannot, because the
+            // nullifier scheme in the extension also prevents it at the tx layer and there
+            // is no signed authority to authorize a replacement.
             if CommunityVotes::<T>::contains_key(poll_index, &voter_key) {
-                ensure!(maybe_who.is_some(), Error::<T>::AlreadyOngoing);
+                ensure!(maybe_who.is_some(), Error::<T>::AnonymousVoteAlreadyCast);
                 Self::try_remove_vote_by_key(&community_id, &voter_key, poll_index)?;
             }
 

--- a/pallets/communities/src/lib.rs
+++ b/pallets/communities/src/lib.rs
@@ -125,7 +125,7 @@ use frame_support::{
 use frame_system::pallet_prelude::{ensure_signed, OriginFor};
 use sp_core::H256;
 use sp_runtime::traits::AccountIdConversion;
-use sp_runtime::traits::{BlockNumberProvider, StaticLookup};
+use sp_runtime::traits::{BlockNumberProvider, Hash as _, StaticLookup};
 
 // TODO: Re-enable after storage model rework
 // #[cfg(feature = "runtime-benchmarks")]
@@ -167,7 +167,8 @@ pub mod pallet {
         frame_system::Config<
         RuntimeEvent: From<Event<Self>>,
         RuntimeCall: From<Call<Self>>,
-        RuntimeOrigin: From<Origin<Self>>,
+        RuntimeOrigin: From<Origin<Self>>
+            + Into<Result<Origin<Self>, <Self as frame_system::Config>::RuntimeOrigin>>,
     >
     where
         AssetIdOf<Self>: MaybeSerializeDeserialize,
@@ -278,14 +279,16 @@ pub mod pallet {
         StorageMap<_, Blake2_128Concat, CommunityIdOf<T>, DecisionMethodFor<T>, ValueQuery>;
 
     /// Stores the list of votes for a community.
+    /// Key: (poll_index, voter_key) where voter_key is hash of account (named) or hash of nullifier (anonymous)
+    /// Value: (vote, multiplied_weight) for correct removal
     #[pallet::storage]
-    pub(super) type CommunityVotes<T> = StorageDoubleMap<
+    pub(super) type CommunityVotes<T: Config> = StorageDoubleMap<
         _,
         Blake2_128Concat,
         PollIndexOf<T>,
         Blake2_128Concat,
-        AccountIdOf<T>,
-        (VoteOf<T>, AccountIdOf<T>),
+        <T::Hasher as sp_runtime::traits::Hash>::Output,
+        (VoteOf<T>, VoteWeight),
     >;
 
     /// Stores the list of votes for a community.
@@ -391,7 +394,7 @@ pub mod pallet {
             sub_track_id: u16,
         },
         VoteCasted {
-            who: AccountIdOf<T>,
+            who: Option<AccountIdOf<T>>,
             poll_index: PollIndexOf<T>,
             vote: VoteOf<T>,
         },
@@ -743,7 +746,8 @@ pub mod pallet {
             Ok(())
         }
 
-        /// Cast a vote on an on-going referendum
+        /// Cast a vote on an on-going referendum.
+        /// Supports both named (signed) and anonymous (community origin) voting paths.
         #[pallet::call_index(8)]
         pub fn vote(
             origin: OriginFor<T>,
@@ -751,44 +755,83 @@ pub mod pallet {
             vote: VoteOf<T>,
         ) -> DispatchResult {
             ensure!(VoteWeight::from(&vote).gt(&0), Error::<T>::VoteBelowMinimum);
-            let who = ensure_signed(origin)?;
 
-            // Get community_id from the poll's class
-            let community_id = T::Polls::as_ongoing(poll_index)
-                .map(|t| t.1)
-                .ok_or(Error::<T>::NotOngoing)?;
-
-            ensure!(
-                Self::is_member(&community_id, &who),
-                Error::<T>::NotAMember
-            );
+            // Determine voting path: signed (named) or community origin (anonymous)
+            let (community_id, voter_key, vote_multiplier, maybe_who): (
+                CommunityIdOf<T>,
+                <T::Hasher as sp_runtime::traits::Hash>::Output,
+                u32,
+                Option<AccountIdOf<T>>,
+            ) = if let Some(who) = origin.as_system_ref()
+                .and_then(|s| if let frame_system::RawOrigin::Signed(who) = s { Some(who.clone()) } else { None })
+            {
+                // Named vote path - signed origin
+                let community_id = T::Polls::as_ongoing(poll_index)
+                    .map(|t| t.1)
+                    .ok_or(Error::<T>::NotOngoing)?;
+                ensure!(Self::is_member(&community_id, &who), Error::<T>::NotAMember);
+                let decision_method = CommunityDecisionMethod::<T>::get(community_id);
+                let multiplier = match decision_method {
+                    DecisionMethod::Rank => Self::member_rank(&community_id, &who).into(),
+                    _ => 1u32,
+                };
+                let key = T::Hasher::hash_of(&who);
+                (community_id, key, multiplier, Some(who))
+            } else {
+                // Anonymous vote path - try community origin
+                let community_origin = Self::extract_community_origin(origin)?;
+                match community_origin.subset() {
+                    Some(origin::Subset::AnonymousMember { rank, nullifier }) => {
+                        let community_id = community_origin.id();
+                        let decision_method = CommunityDecisionMethod::<T>::get(community_id);
+                        // Token-weighted voting not supported anonymously
+                        ensure!(
+                            matches!(decision_method, DecisionMethod::Membership | DecisionMethod::Rank),
+                            Error::<T>::InvalidVoteType
+                        );
+                        let multiplier = match decision_method {
+                            DecisionMethod::Rank => (*rank).into(),
+                            _ => 1u32,
+                        };
+                        let key = T::Hasher::hash_of(nullifier);
+                        (community_id, key, multiplier, None)
+                    },
+                    _ => return Err(DispatchError::BadOrigin),
+                }
+            };
 
             let decision_method = CommunityDecisionMethod::<T>::get(community_id);
-            if CommunityVotes::<T>::contains_key(poll_index, &who) {
-                Self::try_remove_vote(&community_id, &decision_method, &who, poll_index)?;
+
+            // Check for existing vote and remove it (only for named voters)
+            if CommunityVotes::<T>::contains_key(poll_index, &voter_key) {
+                ensure!(maybe_who.is_some(), Error::<T>::AlreadyOngoing);
+                Self::try_remove_vote_by_key(&community_id, &voter_key, poll_index)?;
             }
-            Self::try_vote(
-                &community_id,
-                &decision_method,
-                &who,
-                poll_index,
-                &vote,
-            )?;
+
+            Self::try_vote_by_key(&community_id, &decision_method, vote_multiplier, &voter_key, poll_index, &vote)?;
+
+            // Lock funds only for named voters
+            if let Some(ref who) = maybe_who {
+                Self::update_locks(who, poll_index, &vote, LockUpdateType::Add)?;
+            }
+
             Self::deposit_event(Event::<T>::VoteCasted {
-                who: who.clone(),
+                who: maybe_who,
                 poll_index,
                 vote,
             });
             Ok(())
         }
 
-        /// Remove any previous vote on a given referendum
+        /// Remove any previous vote on a given referendum.
+        /// Only available for named (signed) voters. Anonymous votes cannot be removed.
         #[pallet::call_index(9)]
         pub fn remove_vote(
             origin: OriginFor<T>,
             #[pallet::compact] poll_index: PollIndexOf<T>,
         ) -> DispatchResult {
             let who = ensure_signed(origin)?;
+            let voter_key = T::Hasher::hash_of(&who);
 
             let community_id = T::Polls::as_ongoing(poll_index)
                 .map(|t| t.1)
@@ -799,10 +842,14 @@ pub mod pallet {
                 Error::<T>::NotAMember
             );
 
-            let decision_method = CommunityDecisionMethod::<T>::get(community_id);
-            Self::try_remove_vote(&community_id, &decision_method, &who, poll_index)?;
+            let (vote, _) = CommunityVotes::<T>::get(poll_index, &voter_key)
+                .ok_or(Error::<T>::NoVoteCasted)?;
+
+            Self::try_remove_vote_by_key(&community_id, &voter_key, poll_index)?;
+            Self::update_locks(&who, poll_index, &vote, LockUpdateType::Remove)?;
+
             Self::deposit_event(Event::<T>::VoteRemoved {
-                who: who.clone(),
+                who,
                 poll_index,
             });
             Ok(())

--- a/pallets/communities/src/lib.rs
+++ b/pallets/communities/src/lib.rs
@@ -45,8 +45,8 @@
 //! ```ignore
 //! [       ] --> [Pending]               --> [Active]            --> [Blocked]
 //! create        set_metadata                set_metadata            unblock
-//!                                           block                   
-//!                                           add_member              
+//!                                           block
+//!                                           add_member
 //!                                           remove_member
 //!                                           promote
 //!                                           demote
@@ -114,9 +114,9 @@
 
 extern crate alloc;
 
-use alloc::{boxed::Box, vec::Vec};
+use alloc::boxed::Box;
 use core::num::NonZeroU8;
-use frame_contrib_traits::memberships::{self as membership, Inspect, Manager, Rank};
+use frame_contrib_traits::memberships::GenericRank;
 use frame_support::{
     pallet_prelude::*,
     traits::{fungible, fungibles, EnsureOrigin, OriginTrait, Polling},
@@ -126,13 +126,14 @@ use frame_system::pallet_prelude::{ensure_signed, OriginFor};
 use sp_runtime::traits::AccountIdConversion;
 use sp_runtime::traits::{BlockNumberProvider, StaticLookup};
 
-#[cfg(feature = "runtime-benchmarks")]
-mod benchmarking;
+// TODO: Re-enable after storage model rework
+// #[cfg(feature = "runtime-benchmarks")]
+// mod benchmarking;
 
-#[cfg(test)]
-mod mock;
-#[cfg(test)]
-mod tests;
+// #[cfg(test)]
+// mod mock;
+// #[cfg(test)]
+// mod tests;
 
 mod functions;
 mod impls;
@@ -191,16 +192,15 @@ pub mod pallet {
 
         /// This type represents an unique ID for the community
         type CommunityId: Parameter + MaxEncodedLen + Copy + MaybeSerializeDeserialize;
-        /// This type represents an unique ID to identify a membership within a
-        /// community
-        type MembershipId: Parameter + MaxEncodedLen + Copy + MaybeSerializeDeserialize;
+
+        /// The hashing algorithm used for merkle trees
+        type Hasher: sp_runtime::traits::Hash;
+
+        /// Maximum number of members a community can have
+        type MaxMembers: Get<u32>;
 
         // Dependencies: The external components this pallet depends on.
 
-        /// Means to manage memberships of a community
-        type MemberMgmt: Inspect<Self::AccountId, Group = CommunityIdOf<Self>, Membership = MembershipIdOf<Self>>
-            + Manager<Self::AccountId, Group = CommunityIdOf<Self>, Membership = MembershipIdOf<Self>>
-            + Rank<Self::AccountId, Group = CommunityIdOf<Self>, Membership = MembershipIdOf<Self>>;
         /// Means to read and mutate the state of a poll.
         type Polls: Polling<
             Tally<Self>,
@@ -281,7 +281,7 @@ pub mod pallet {
         Blake2_128Concat,
         PollIndexOf<T>,
         Blake2_128Concat,
-        MembershipIdOf<T>,
+        AccountIdOf<T>,
         (VoteOf<T>, AccountIdOf<T>),
     >;
 
@@ -295,6 +295,48 @@ pub mod pallet {
         PollIndexOf<T>,
         VoteOf<T>,
     >;
+
+    /// Merkle root for private community membership proofs
+    #[pallet::storage]
+    pub type MerkleRoot<T: Config> =
+        StorageMap<_, Blake2_128Concat, CommunityIdOf<T>, <T::Hasher as sp_runtime::traits::Hash>::Output>;
+
+    /// Sub-roots for sharded membership trees
+    #[pallet::storage]
+    pub type SubRoots<T: Config> = StorageDoubleMap<
+        _,
+        Blake2_128Concat,
+        CommunityIdOf<T>,
+        Blake2_128Concat,
+        u16,
+        <T::Hasher as sp_runtime::traits::Hash>::Output,
+    >;
+
+    /// Number of members in a community
+    #[pallet::storage]
+    pub type MemberCount<T: Config> =
+        StorageMap<_, Blake2_128Concat, CommunityIdOf<T>, u32, ValueQuery>;
+
+    /// Total of all member ranks in a community (for rank-weighted voting)
+    #[pallet::storage]
+    pub type RanksTotal<T: Config> =
+        StorageMap<_, Blake2_128Concat, CommunityIdOf<T>, u32, ValueQuery>;
+
+    /// On-chain member records
+    #[pallet::storage]
+    pub type Members<T: Config> = StorageDoubleMap<
+        _,
+        Blake2_128Concat,
+        CommunityIdOf<T>,
+        Blake2_128Concat,
+        AccountIdOf<T>,
+        MemberRecord,
+    >;
+
+    /// Gas/transaction budget for a community
+    #[pallet::storage]
+    pub type Budget<T: Config> =
+        StorageMap<_, Blake2_128Concat, CommunityIdOf<T>, CommunityBudget<BlockNumberFor<T>>>;
 
     // Pallets use events to inform users when important changes are made.
     // https://docs.substrate.io/main-docs/build/events-errors/
@@ -315,15 +357,13 @@ pub mod pallet {
         },
         MemberAdded {
             who: AccountIdOf<T>,
-            membership_id: MembershipIdOf<T>,
         },
         MemberRemoved {
             who: AccountIdOf<T>,
-            membership_id: MembershipIdOf<T>,
         },
-        MembershipRankUpdated {
-            membership_id: MembershipIdOf<T>,
-            rank: membership::GenericRank,
+        MemberRankUpdated {
+            who: AccountIdOf<T>,
+            rank: GenericRank,
         },
         VoteCasted {
             who: AccountIdOf<T>,
@@ -349,6 +389,8 @@ pub mod pallet {
         /// The specified [`AccountId`][`frame_system::Config::AccountId`] is
         /// not a member of the community
         NotAMember,
+        /// The account is already a member of this community
+        AlreadyMember,
         /// The indicated index corresponds to a poll that is already ongoing
         AlreadyOngoing,
         /// The indicated index corresponds to a poll that is not ongoing
@@ -419,80 +461,108 @@ pub mod pallet {
 
         // === Memberships management ===
 
-        /// Enroll an account as a community member that receives a membership
-        /// from the available pool of memberships of the community.
+        /// Enroll an account as a community member.
         #[pallet::call_index(3)]
         pub fn add_member(origin: OriginFor<T>, who: AccountIdLookupOf<T>) -> DispatchResult {
             let community_id = T::MemberMgmtOrigin::ensure_origin(origin)?;
             let who = T::Lookup::lookup(who)?;
 
-            let account = Self::community_account(&community_id);
-            // assume the community has memberships to give out to the new member
-            let (_, membership_id) = T::MemberMgmt::user_memberships(&account, None)
-                .next()
-                .ok_or(Error::<T>::CommunityAtCapacity)?;
+            let info = Info::<T>::get(&community_id).ok_or(Error::<T>::CommunityDoesNotExist)?;
+            ensure!(
+                info.state == CommunityState::Active,
+                Error::<T>::CommunityDoesNotExist
+            );
+            ensure!(
+                !Members::<T>::contains_key(&community_id, &who),
+                Error::<T>::AlreadyMember
+            );
 
-            T::MemberMgmt::assign(&community_id, &membership_id, &who)?;
+            let count = MemberCount::<T>::get(&community_id);
+            let max = if info.capacity > 0 {
+                info.capacity
+            } else {
+                T::MaxMembers::get()
+            };
+            ensure!(count < max, Error::<T>::CommunityAtCapacity);
 
-            Self::deposit_event(Event::MemberAdded { who, membership_id });
+            Members::<T>::insert(&community_id, &who, MemberRecord::default());
+            MemberCount::<T>::mutate(&community_id, |c| *c = c.saturating_add(1));
+
+            Self::deposit_event(Event::MemberAdded { who });
             Ok(())
         }
 
-        /// Removes an account as a community member. While
-        /// enrolling a member into the community can be an action taken by any
-        /// member, the decision to remove a member should not be taken
-        /// arbitrarily by any community member. Also, it shouldn't be possible
-        /// to arbitrarily remove the community admin, as some privileged calls
-        /// would be impossible to execute thereafter.
+        /// Removes an account as a community member.
         #[pallet::call_index(4)]
         pub fn remove_member(
             origin: OriginFor<T>,
             who: AccountIdLookupOf<T>,
-            membership_id: MembershipIdOf<T>,
         ) -> DispatchResult {
             let community_id = T::MemberMgmtOrigin::ensure_origin(origin)?;
             let who = T::Lookup::lookup(who)?;
 
-            ensure!(
-                T::MemberMgmt::is_member_of(&community_id, &who),
-                Error::<T>::NotAMember
-            );
+            let record =
+                Members::<T>::get(&community_id, &who).ok_or(Error::<T>::NotAMember)?;
 
-            T::MemberMgmt::release(&community_id, &membership_id)?;
+            Members::<T>::remove(&community_id, &who);
+            MemberCount::<T>::mutate(&community_id, |c| *c = c.saturating_sub(1));
+            let rank_val: u32 = record.rank.into();
+            if rank_val > 0 {
+                RanksTotal::<T>::mutate(&community_id, |t| *t = t.saturating_sub(rank_val));
+            }
 
-            Self::deposit_event(Event::MemberRemoved { who, membership_id });
+            Self::deposit_event(Event::MemberRemoved { who });
             Ok(())
         }
 
         /// Increases the rank of a member in the community
         #[pallet::call_index(5)]
-        pub fn promote(origin: OriginFor<T>, membership_id: MembershipIdOf<T>) -> DispatchResult {
+        pub fn promote(origin: OriginFor<T>, who: AccountIdLookupOf<T>) -> DispatchResult {
             let community_id = T::MemberMgmtOrigin::ensure_origin(origin)?;
+            let who = T::Lookup::lookup(who)?;
 
-            let rank = T::MemberMgmt::rank_of(&community_id, &membership_id)
-                .ok_or(Error::<T>::NotAMember)?
-                .promote_by(ONE);
-            T::MemberMgmt::set_rank(&community_id, &membership_id, rank)?;
+            let mut record =
+                Members::<T>::get(&community_id, &who).ok_or(Error::<T>::NotAMember)?;
 
-            Self::deposit_event(Event::MembershipRankUpdated {
-                membership_id,
-                rank,
+            let new_rank = record.rank.promote_by(ONE);
+            let old_rank_val: u32 = record.rank.into();
+            let new_rank_val: u32 = new_rank.into();
+            record.rank = new_rank;
+
+            Members::<T>::insert(&community_id, &who, &record);
+            RanksTotal::<T>::mutate(&community_id, |t| {
+                *t = t.saturating_sub(old_rank_val).saturating_add(new_rank_val);
+            });
+
+            Self::deposit_event(Event::MemberRankUpdated {
+                who,
+                rank: new_rank,
             });
             Ok(())
         }
 
         /// Decreases the rank of a member in the community
         #[pallet::call_index(6)]
-        pub fn demote(origin: OriginFor<T>, membership_id: MembershipIdOf<T>) -> DispatchResult {
+        pub fn demote(origin: OriginFor<T>, who: AccountIdLookupOf<T>) -> DispatchResult {
             let community_id = T::MemberMgmtOrigin::ensure_origin(origin)?;
+            let who = T::Lookup::lookup(who)?;
 
-            let rank = T::MemberMgmt::rank_of(&community_id, &membership_id)
-                .ok_or(Error::<T>::NotAMember)?;
-            T::MemberMgmt::set_rank(&community_id, &membership_id, rank.demote_by(ONE))?;
+            let mut record =
+                Members::<T>::get(&community_id, &who).ok_or(Error::<T>::NotAMember)?;
 
-            Self::deposit_event(Event::MembershipRankUpdated {
-                membership_id,
-                rank,
+            let new_rank = record.rank.demote_by(ONE);
+            let old_rank_val: u32 = record.rank.into();
+            let new_rank_val: u32 = new_rank.into();
+            record.rank = new_rank;
+
+            Members::<T>::insert(&community_id, &who, &record);
+            RanksTotal::<T>::mutate(&community_id, |t| {
+                *t = t.saturating_sub(old_rank_val).saturating_add(new_rank_val);
+            });
+
+            Self::deposit_event(Event::MemberRankUpdated {
+                who,
+                rank: new_rank,
             });
             Ok(())
         }
@@ -525,23 +595,30 @@ pub mod pallet {
         #[pallet::call_index(8)]
         pub fn vote(
             origin: OriginFor<T>,
-            membership_id: MembershipIdOf<T>,
             #[pallet::compact] poll_index: PollIndexOf<T>,
             vote: VoteOf<T>,
         ) -> DispatchResult {
             ensure!(VoteWeight::from(&vote).gt(&0), Error::<T>::VoteBelowMinimum);
             let who = ensure_signed(origin)?;
-            let community_id = T::MemberMgmt::check_membership(&who, &membership_id)
-                .ok_or(Error::<T>::NotAMember)?;
+
+            // Get community_id from the poll's class
+            let community_id = T::Polls::as_ongoing(poll_index)
+                .map(|t| t.1)
+                .ok_or(Error::<T>::NotOngoing)?;
+
+            ensure!(
+                Self::is_member(&community_id, &who),
+                Error::<T>::NotAMember
+            );
+
             let decision_method = CommunityDecisionMethod::<T>::get(community_id);
-            if CommunityVotes::<T>::contains_key(poll_index, membership_id) {
-                Self::try_remove_vote(&community_id, &decision_method, &membership_id, poll_index)?;
+            if CommunityVotes::<T>::contains_key(poll_index, &who) {
+                Self::try_remove_vote(&community_id, &decision_method, &who, poll_index)?;
             }
             Self::try_vote(
                 &community_id,
                 &decision_method,
                 &who,
-                &membership_id,
                 poll_index,
                 &vote,
             )?;
@@ -557,14 +634,21 @@ pub mod pallet {
         #[pallet::call_index(9)]
         pub fn remove_vote(
             origin: OriginFor<T>,
-            membership_id: MembershipIdOf<T>,
             #[pallet::compact] poll_index: PollIndexOf<T>,
         ) -> DispatchResult {
             let who = ensure_signed(origin)?;
-            let community_id = T::MemberMgmt::check_membership(&who, &membership_id)
-                .ok_or(Error::<T>::NotAMember)?;
+
+            let community_id = T::Polls::as_ongoing(poll_index)
+                .map(|t| t.1)
+                .ok_or(Error::<T>::NotOngoing)?;
+
+            ensure!(
+                Self::is_member(&community_id, &who),
+                Error::<T>::NotAMember
+            );
+
             let decision_method = CommunityDecisionMethod::<T>::get(community_id);
-            Self::try_remove_vote(&community_id, &decision_method, &membership_id, poll_index)?;
+            Self::try_remove_vote(&community_id, &decision_method, &who, poll_index)?;
             Self::deposit_event(Event::<T>::VoteRemoved {
                 who: who.clone(),
                 poll_index,

--- a/pallets/communities/src/lib.rs
+++ b/pallets/communities/src/lib.rs
@@ -123,6 +123,7 @@ use frame_support::{
     Blake2_128Concat, Parameter,
 };
 use frame_system::pallet_prelude::{ensure_signed, OriginFor};
+use sp_core::H256;
 use sp_runtime::traits::AccountIdConversion;
 use sp_runtime::traits::{BlockNumberProvider, StaticLookup};
 
@@ -147,6 +148,8 @@ pub mod weights;
 pub use weights::*;
 
 pub mod origin;
+
+pub mod extensions;
 
 #[frame_support::pallet]
 pub mod pallet {
@@ -310,6 +313,18 @@ pub mod pallet {
         Blake2_128Concat,
         u16,
         <T::Hasher as sp_runtime::traits::Hash>::Output,
+    >;
+
+    /// Tracks used nullifiers to prevent double-actions per scope
+    #[pallet::storage]
+    pub type UsedNullifiers<T: Config> = StorageNMap<
+        _,
+        (
+            NMapKey<Blake2_128Concat, CommunityIdOf<T>>,
+            NMapKey<Blake2_128Concat, H256>,
+            NMapKey<Blake2_128Concat, H256>,
+        ),
+        (),
     >;
 
     /// Number of members in a community

--- a/pallets/communities/src/lib.rs
+++ b/pallets/communities/src/lib.rs
@@ -43,14 +43,12 @@
 //! ## Lifecycle
 //!
 //! ```ignore
-//! [       ] --> [Pending]               --> [Active]            --> [Blocked]
-//! create        set_metadata                set_metadata            unblock
-//!                                           block
-//!                                           add_member
-//!                                           remove_member
-//!                                           promote
-//!                                           demote
-//!                                           set_voting_mechanism
+//! [       ] --> [Active] <-----> [Blocked]
+//! create        add_member       block/unblock
+//!               remove_member
+//!               promote
+//!               demote
+//!               set_decision_method
 //! ```
 //!
 //! ## Implementations
@@ -477,6 +475,9 @@ pub mod pallet {
         /// An anonymous vote has already been cast for this voter on this poll.
         /// Anonymous votes are immutable: they cannot be changed or removed.
         AnonymousVoteAlreadyCast,
+        /// The caller is authorized by origin but not by role (e.g. a rank-0 member
+        /// trying to suspend another member).
+        NotAuthorized,
     }
 
     // Dispatchable functions allows users to interact with the pallet and invoke
@@ -536,7 +537,7 @@ pub mod pallet {
             rank: Option<GenericRank>,
             role: Option<Role>,
         ) -> DispatchResult {
-            let community_id = T::MemberMgmtOrigin::ensure_origin(origin)?;
+            let community_id = Self::ensure_member_mgmt(origin)?;
             let who = T::Lookup::lookup(who)?;
 
             let info = Info::<T>::get(&community_id).ok_or(Error::<T>::CommunityDoesNotExist)?;
@@ -553,13 +554,16 @@ pub mod pallet {
                 Error::<T>::AlreadyMember
             );
 
+            // `capacity == 0` is interpreted as "explicit zero" (no members allowed) —
+            // avoid the previous silent fallback to T::MaxMembers which made capacity=0
+            // mean "unlimited-ish". A runtime that wants the default should read
+            // T::MaxMembers directly when creating the community.
             let count = MemberCount::<T>::get(&community_id);
-            let max = if info.capacity > 0 {
-                info.capacity
-            } else {
-                T::MaxMembers::get()
-            };
-            ensure!(count < max, Error::<T>::CommunityAtCapacity);
+            ensure!(count < info.capacity, Error::<T>::CommunityAtCapacity);
+            ensure!(
+                count < T::MaxMembers::get(),
+                Error::<T>::CommunityAtCapacity,
+            );
 
             let member_rank = rank.unwrap_or_default();
             let member_role = role.unwrap_or_default();
@@ -590,7 +594,7 @@ pub mod pallet {
             origin: OriginFor<T>,
             who: AccountIdLookupOf<T>,
         ) -> DispatchResult {
-            let community_id = T::MemberMgmtOrigin::ensure_origin(origin)?;
+            let community_id = Self::ensure_member_mgmt(origin)?;
             let who = T::Lookup::lookup(who)?;
 
             let record =
@@ -611,7 +615,7 @@ pub mod pallet {
         /// Increases the rank of a member in the community
         #[pallet::call_index(5)]
         pub fn promote(origin: OriginFor<T>, who: AccountIdLookupOf<T>) -> DispatchResult {
-            let community_id = T::MemberMgmtOrigin::ensure_origin(origin)?;
+            let community_id = Self::ensure_member_mgmt(origin)?;
             let who = T::Lookup::lookup(who)?;
 
             let mut record =
@@ -638,7 +642,7 @@ pub mod pallet {
         /// Decreases the rank of a member in the community
         #[pallet::call_index(6)]
         pub fn demote(origin: OriginFor<T>, who: AccountIdLookupOf<T>) -> DispatchResult {
-            let community_id = T::MemberMgmtOrigin::ensure_origin(origin)?;
+            let community_id = Self::ensure_member_mgmt(origin)?;
             let who = T::Lookup::lookup(who)?;
 
             let mut record =
@@ -668,7 +672,7 @@ pub mod pallet {
             origin: OriginFor<T>,
             who: AccountIdLookupOf<T>,
         ) -> DispatchResult {
-            let community_id = T::MemberMgmtOrigin::ensure_origin(origin)?;
+            let community_id = Self::ensure_member_mgmt(origin)?;
             let who = T::Lookup::lookup(who)?;
 
             let mut record =
@@ -921,8 +925,48 @@ pub mod pallet {
             origin: OriginFor<T>,
             call: Box<RuntimeCallFor<T>>,
         ) -> DispatchResult {
-            let community_id = T::MemberMgmtOrigin::ensure_origin(origin)?;
+            let community_id = Self::ensure_member_mgmt(origin)?;
             Self::do_dispatch_as_community_account(&community_id, *call)
+        }
+
+        /// Remove a stored vote entry for a poll that has ended. Permissionless: any
+        /// account can call this for any `(poll_index, voter_key)` once the poll is no
+        /// longer ongoing. Addresses storage bloat, including for anonymous votes whose
+        /// voter has no on-chain identity to clean up after themselves.
+        #[pallet::call_index(16)]
+        #[pallet::weight((T::DbWeight::get().reads_writes(1, 1), DispatchClass::Normal))]
+        pub fn prune_vote(
+            origin: OriginFor<T>,
+            #[pallet::compact] poll_index: PollIndexOf<T>,
+            voter_key: <T::Hasher as sp_runtime::traits::Hash>::Output,
+        ) -> DispatchResult {
+            let _ = ensure_signed(origin)?;
+            ensure!(
+                T::Polls::as_ongoing(poll_index).is_none(),
+                Error::<T>::AlreadyOngoing,
+            );
+            ensure!(
+                CommunityVotes::<T>::contains_key(poll_index, &voter_key),
+                Error::<T>::NoVoteCasted,
+            );
+            CommunityVotes::<T>::remove(poll_index, &voter_key);
+            Ok(())
+        }
+
+        /// Remove a stored sub-root. Admin-only.
+        #[pallet::call_index(17)]
+        #[pallet::weight((T::DbWeight::get().reads_writes(0, 1), DispatchClass::Normal))]
+        pub fn remove_sub_root(
+            origin: OriginFor<T>,
+            sub_track_id: u16,
+        ) -> DispatchResult {
+            let community_id = T::AdminOrigin::ensure_origin(origin)?;
+            SubRoots::<T>::remove(&community_id, sub_track_id);
+            Self::deposit_event(Event::SubRootUpdated {
+                community_id,
+                sub_track_id,
+            });
+            Ok(())
         }
     }
 }

--- a/pallets/communities/src/lib.rs
+++ b/pallets/communities/src/lib.rs
@@ -384,6 +384,9 @@ pub mod pallet {
             who: AccountIdOf<T>,
             poll_index: PollIndexOf<T>,
         },
+        BudgetSet {
+            community_id: CommunityIdOf<T>,
+        },
     }
 
     // Errors inform users that something worked or went wrong.
@@ -426,6 +429,8 @@ pub mod pallet {
         CommunityIsPublic,
         /// The member is suspended
         MemberIsSuspended,
+        /// The community's gas budget has been exhausted
+        BudgetExhausted,
     }
 
     // Dispatchable functions allows users to interact with the pallet and invoke
@@ -674,6 +679,28 @@ pub mod pallet {
                 community_id,
                 sub_track_id,
             });
+            Ok(())
+        }
+
+        // === Budget ===
+
+        /// Set the gas budget for a community
+        #[pallet::call_index(15)]
+        pub fn set_budget(
+            origin: OriginFor<T>,
+            capacity: u64,
+            session_length: BlockNumberFor<T>,
+        ) -> DispatchResult {
+            let community_id = T::AdminOrigin::ensure_origin(origin)?;
+            ensure!(Self::community_exists(&community_id), Error::<T>::CommunityDoesNotExist);
+            let now = T::BlockNumberProvider::current_block_number();
+            Budget::<T>::insert(&community_id, CommunityBudget {
+                capacity,
+                used: 0,
+                session_start: now,
+                session_length,
+            });
+            Self::deposit_event(Event::BudgetSet { community_id });
             Ok(())
         }
 

--- a/pallets/communities/src/mock.rs
+++ b/pallets/communities/src/mock.rs
@@ -250,6 +250,7 @@ impl Config for Test {
 
     type CommunityId = CommunityId;
     type Hasher = BlakeTwo256;
+    type MembershipVerifier = crate::verifier::MerkleVerifier<BlakeTwo256>;
     type MaxMembers = ConstU32<100>;
 
     type Polls = Referenda;

--- a/pallets/communities/src/mock.rs
+++ b/pallets/communities/src/mock.rs
@@ -5,10 +5,7 @@ use frame_support::{
         EitherOf, EnsureOriginWithArg, EqualPrivilegeOnly, Footprint,
         OriginTrait, VariantCountOf,
     },
-    weights::{
-        constants::{WEIGHT_REF_TIME_PER_NANOS, WEIGHT_REF_TIME_PER_SECOND},
-        Weight,
-    },
+    weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
     PalletId,
 };
 use frame_system::{EnsureRoot, EnsureRootWithSuccess, EnsureSigned};
@@ -31,7 +28,6 @@ use crate::{
 // Weights constants
 pub const MAX_BLOCK_REF_TIME: u64 = WEIGHT_REF_TIME_PER_SECOND.saturating_div(2);
 pub const MAX_BLOCK_POV_SIZE: u64 = 5 * 1024 * 1024;
-pub const MAX_BLOCK_WEIGHT: Weight = Weight::from_parts(MAX_BLOCK_REF_TIME, MAX_BLOCK_POV_SIZE);
 type Block = frame_system::mocking::MockBlock<Test>;
 type WeightInfo = ();
 

--- a/pallets/communities/src/mock.rs
+++ b/pallets/communities/src/mock.rs
@@ -1,12 +1,9 @@
-use frame_contrib_traits::memberships::NonFungiblesMemberships;
 use frame_support::{
-    derive_impl,
-    dispatch::DispatchResult,
-    parameter_types,
+    derive_impl, parameter_types,
     traits::{
-        fungible::HoldConsideration, tokens::nonfungible_v2::ItemOf, AsEnsureOriginWithArg,
-        ConstU32, ConstU64, EitherOf, EnsureOriginWithArg, EqualPrivilegeOnly, Footprint,
-        VariantCountOf,
+        fungible::HoldConsideration, AsEnsureOriginWithArg, ConstU32, ConstU64,
+        EitherOf, EnsureOriginWithArg, EqualPrivilegeOnly, Footprint,
+        OriginTrait, VariantCountOf,
     },
     weights::{
         constants::{WEIGHT_REF_TIME_PER_NANOS, WEIGHT_REF_TIME_PER_SECOND},
@@ -15,48 +12,33 @@ use frame_support::{
     PalletId,
 };
 use frame_system::{EnsureRoot, EnsureRootWithSuccess, EnsureSigned};
-use pallet_referenda::{TrackIdOf, TrackInfoOf, TracksInfo};
+use pallet_referenda::{TrackIdOf, TracksInfo};
 use sp_io::TestExternalities;
 use sp_runtime::{
-    traits::{Convert, IdentifyAccount, IdentityLookup, Verify},
-    BuildStorage, MultiSignature, Perbill,
+    traits::{BlakeTwo256, Convert, IdentifyAccount, IdentityLookup, Verify},
+    BuildStorage, MultiSignature,
 };
 
-pub type CommunityId = u16;
-pub type MembershipId = u64;
+pub type CommunityId = u32;
 
 use crate::{
     self as pallet_communities,
     origin::{EnsureCommunity, EnsureSignedPays},
     types::{Tally, VoteWeight},
-    Config, DecisionMethod,
+    Config, PrivacyLevel,
 };
 
 // Weights constants
-
-// max block: 0.5s compute with 12s average block time
-pub const MAX_BLOCK_REF_TIME: u64 = WEIGHT_REF_TIME_PER_SECOND.saturating_div(2); // https://github.com/paritytech/cumulus/blob/98e68bd54257b4039a5d5b734816f4a1b7c83a9d/parachain-template/runtime/src/lib.rs#L221
-pub const MAX_BLOCK_POV_SIZE: u64 = 5 * 1024 * 1024; // https://github.com/paritytech/polkadot/blob/ba1f65493d91d4ab1787af2fd6fe880f1da90586/primitives/src/v4/mod.rs#L384
+pub const MAX_BLOCK_REF_TIME: u64 = WEIGHT_REF_TIME_PER_SECOND.saturating_div(2);
+pub const MAX_BLOCK_POV_SIZE: u64 = 5 * 1024 * 1024;
 pub const MAX_BLOCK_WEIGHT: Weight = Weight::from_parts(MAX_BLOCK_REF_TIME, MAX_BLOCK_POV_SIZE);
-
-// max extrinsics: 75% of block
-pub const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75); // https://github.com/paritytech/cumulus/blob/d20c4283fe85df0c1ef8cb7c9eb7c09abbcbfa31/parachain-template/runtime/src/lib.rs#L218
-
-// max extrinsic: max total extrinsics less average on_initialize ratio and less
-// base extrinsic weight
-pub const AVERAGE_ON_INITIALIZE_RATIO: Perbill = Perbill::from_percent(5); // https://github.com/paritytech/cumulus/blob/d20c4283fe85df0c1ef8cb7c9eb7c09abbcbfa31/parachain-template/runtime/src/lib.rs#L214
-pub const BASE_EXTRINSIC: Weight =
-    Weight::from_parts(WEIGHT_REF_TIME_PER_NANOS.saturating_mul(125_000), 0); // https://github.com/paritytech/cumulus/blob/d20c4283fe85df0c1ef8cb7c9eb7c09abbcbfa31/parachain-template/runtime/src/weights/extrinsic_weights.rs#L26
-
 type Block = frame_system::mocking::MockBlock<Test>;
 type WeightInfo = ();
 
 pub type AccountPublic = <MultiSignature as Verify>::Signer;
 pub type AccountId = <AccountPublic as IdentifyAccount>::AccountId;
 pub type Balance = <Test as pallet_balances::Config>::Balance;
-pub type AssetId = <Test as pallet_assets::Config>::AssetId;
 
-// Configure a mock runtime to test the pallet.
 #[frame_support::runtime]
 mod runtime {
     #[runtime::runtime]
@@ -91,8 +73,6 @@ mod runtime {
     pub type Communities = pallet_communities;
     #[runtime::pallet_index(32)]
     pub type Tracks = fc_pallet_referenda_tracks;
-    #[runtime::pallet_index(33)]
-    pub type Nfts = pallet_nfts;
 }
 
 #[derive_impl(frame_system::config_preludes::TestDefaultConfig as frame_system::DefaultConfig)]
@@ -103,9 +83,7 @@ impl frame_system::Config for Test {
     type AccountData = pallet_balances::AccountData<Balance>;
 }
 
-// Monetary operations
-#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig as pallet_balances::DefaultConfig
-)]
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig as pallet_balances::DefaultConfig)]
 impl pallet_balances::Config for Test {
     type AccountStore = System;
     type FreezeIdentifier = RuntimeFreezeReason;
@@ -127,79 +105,12 @@ impl pallet_assets_freezer::Config for Test {
     type RuntimeEvent = RuntimeEvent;
 }
 
-// Memberships
-#[cfg(feature = "runtime-benchmarks")]
-pub struct NftsBenchmarksHelper;
-#[cfg(feature = "runtime-benchmarks")]
-impl
-    pallet_nfts::BenchmarkHelper<
-        CommunityId,
-        MembershipId,
-        AccountPublic,
-        AccountId,
-        MultiSignature,
-    > for NftsBenchmarksHelper
-{
-    fn collection(_i: u16) -> CommunityId {
-        COMMUNITY
-    }
-    fn item(i: u16) -> MembershipId {
-        i as MembershipId
-    }
-    fn signer() -> (AccountPublic, AccountId) {
-        let public = sp_io::crypto::sr25519_generate(0.into(), None);
-        let account = sp_runtime::MultiSigner::Sr25519(public).into_account();
-        (public.into(), account)
-    }
-    fn sign(signer: &AccountPublic, message: &[u8]) -> MultiSignature {
-        MultiSignature::Sr25519(
-            sp_io::crypto::sr25519_sign(0.into(), &signer.clone().try_into().unwrap(), message)
-                .unwrap(),
-        )
-    }
-}
-
-parameter_types! {
-    pub const RootAccount: AccountId = AccountId::new([0xff; 32]);
-}
-impl pallet_nfts::Config for Test {
-    type RuntimeEvent = RuntimeEvent;
-    type CollectionId = CommunityId;
-    type ItemId = MembershipId;
-    type Currency = ();
-    type ForceOrigin = EnsureRoot<AccountId>;
-    type CreateOrigin = AsEnsureOriginWithArg<
-        EitherOf<EnsureRootWithSuccess<AccountId, RootAccount>, EnsureSigned<AccountId>>,
-    >;
-    type Locker = ();
-    type CollectionDeposit = ();
-    type ItemDeposit = ();
-    type MetadataDepositBase = ();
-    type AttributeDepositBase = ();
-    type DepositPerByte = ();
-    type StringLimit = ();
-    type KeyLimit = ConstU32<64>;
-    type ValueLimit = ConstU32<10>;
-    type ApprovalsLimit = ();
-    type ItemAttributesApprovalsLimit = ();
-    type MaxTips = ();
-    type MaxDeadlineDuration = ();
-    type MaxAttributesPerCall = ();
-    type Features = ();
-    type OffchainSignature = MultiSignature;
-    type OffchainPublic = AccountPublic;
-    #[cfg(feature = "runtime-benchmarks")]
-    type Helper = NftsBenchmarksHelper;
-
-    type WeightInfo = ();
-    type BlockNumberProvider = System;
-}
-
-// Governance at Communities
+// Governance
 parameter_types! {
     pub MaximumSchedulerWeight: Weight = Weight::from_parts(MAX_BLOCK_REF_TIME, MAX_BLOCK_POV_SIZE);
     pub const MaxScheduledPerBlock: u32 = 512;
 }
+
 pub struct ConvertDeposit;
 impl Convert<Footprint, u64> for ConvertDeposit {
     fn convert(a: Footprint) -> u64 {
@@ -244,7 +155,6 @@ impl EnsureOriginWithArg<RuntimeOrigin, TrackIdOf<Test, ()>> for EnsureOriginToT
         let track_id_for_origin: TrackIdOf<Test, ()> =
             Tracks::track_for(&o.clone().caller).map_err(|_| o.clone())?;
         frame_support::ensure!(&track_id_for_origin == id, o);
-
         Ok(())
     }
 
@@ -254,23 +164,10 @@ impl EnsureOriginWithArg<RuntimeOrigin, TrackIdOf<Test, ()>> for EnsureOriginToT
     }
 }
 
-#[cfg(feature = "runtime-benchmarks")]
-use sp_runtime::SaturatedConversion;
-
-#[cfg(feature = "runtime-benchmarks")]
-pub struct TracksBenchmarkHelper;
-
-#[cfg(feature = "runtime-benchmarks")]
-impl fc_pallet_referenda_tracks::BenchmarkHelper<Test> for TracksBenchmarkHelper {
-    fn track_id(id: u32) -> TrackIdOf<Test, ()> {
-        id.saturated_into()
-    }
-}
-
 parameter_types! {
     pub const MaxTracks: u32 = u32::MAX;
 }
-/// Returns a default group ID (0) when root creates a sub-track.
+
 pub struct EnsureRootReturnGroupId;
 impl EnsureOriginWithArg<RuntimeOrigin, pallet_referenda::PalletsOriginOf<Test>>
     for EnsureRootReturnGroupId
@@ -286,7 +183,7 @@ impl EnsureOriginWithArg<RuntimeOrigin, pallet_referenda::PalletsOriginOf<Test>>
     }
 
     #[cfg(feature = "runtime-benchmarks")]
-    fn try_successful_origin(_arg: &PalletsOriginOf<Test>) -> Result<RuntimeOrigin, ()> {
+    fn try_successful_origin(_arg: &pallet_referenda::PalletsOriginOf<Test>) -> Result<RuntimeOrigin, ()> {
         Ok(RuntimeOrigin::root())
     }
 }
@@ -305,8 +202,9 @@ impl fc_pallet_referenda_tracks::Config for Test {
 }
 
 parameter_types! {
-        pub static AlarmInterval: u64 = 1;
+    pub static AlarmInterval: u64 = 1;
 }
+
 impl pallet_referenda::Config for Test {
     type RuntimeCall = RuntimeCall;
     type RuntimeEvent = RuntimeEvent;
@@ -332,142 +230,15 @@ impl pallet_referenda::Config for Test {
 
 parameter_types! {
     pub const CommunitiesPalletId: PalletId = PalletId(*b"kv/comms");
-    pub const MembershipsManagerCollectionId: CommunityId = 0;
-    pub const MembershipNftAttr: &'static [u8; 10] = b"membership";
-    pub const TestCommunity: CommunityId = COMMUNITY;
-}
-
-type MembershipCollection = ItemOf<Nfts, MembershipsManagerCollectionId, AccountId>;
-
-#[cfg(feature = "runtime-benchmarks")]
-use crate::{
-    types::{AssetIdOf, CommunityIdOf, MembershipIdOf, PollIndexOf},
-    BenchmarkHelper,
-};
-
-#[cfg(feature = "runtime-benchmarks")]
-use {
-    codec::Encode,
-    frame_benchmarking::BenchmarkError,
-    frame_support::BoundedVec,
-    frame_system::pallet_prelude::{OriginFor, RuntimeCallFor},
-    pallet_referenda::{BoundedCallOf, Curve, PalletsOriginOf, TrackInfo},
-};
-
-#[cfg(feature = "runtime-benchmarks")]
-pub struct CommunityBenchmarkHelper;
-
-#[cfg(feature = "runtime-benchmarks")]
-impl BenchmarkHelper<Test> for CommunityBenchmarkHelper {
-    fn community_id() -> CommunityIdOf<Test> {
-        COMMUNITY
-    }
-
-    fn community_asset_id() -> AssetIdOf<Test> {
-        1u32
-    }
-
-    fn community_desired_size() -> u32 {
-        u8::MAX as u32
-    }
-
-    fn initialize_memberships_collection() -> Result<(), frame_benchmarking::BenchmarkError> {
-        TestEnvBuilder::initialize_memberships_manager_collection()?;
-        TestEnvBuilder::initialize_community_memberships_collection(&Self::community_id())?;
-        Ok(())
-    }
-
-    fn issue_membership(
-        community_id: CommunityIdOf<Test>,
-        membership_id: MembershipIdOf<Test>,
-    ) -> Result<(), frame_benchmarking::BenchmarkError> {
-        use frame_support::traits::tokens::nonfungible_v2::Mutate;
-
-        let community_account = Communities::community_account(&community_id);
-        MembershipCollection::mint_into(
-            &membership_id,
-            &community_account,
-            &Default::default(),
-            true,
-        )?;
-
-        Ok(())
-    }
-
-    fn prepare_track(track_origin: PalletsOriginOf<Test>) -> Result<(), BenchmarkError> {
-        let id = Self::community_id();
-        let info = TrackInfo {
-            name: sp_runtime::str_array("Community"),
-            max_deciding: 1,
-            decision_deposit: 5,
-            prepare_period: 1,
-            decision_period: 5,
-            confirm_period: 1,
-            min_enactment_period: 1,
-            min_approval: Curve::LinearDecreasing {
-                length: Perbill::from_percent(100),
-                floor: Perbill::from_percent(50),
-                ceil: Perbill::from_percent(100),
-            },
-            min_support: Curve::LinearDecreasing {
-                length: Perbill::from_percent(100),
-                floor: Perbill::from_percent(0),
-                ceil: Perbill::from_percent(100),
-            },
-        };
-
-        Tracks::do_insert(id, info, track_origin.clone())?;
-
-        Ok(())
-    }
-
-    fn prepare_poll(
-        origin: OriginFor<Test>,
-        proposal_origin: PalletsOriginOf<Test>,
-        proposal_call: RuntimeCallFor<Test>,
-    ) -> Result<PollIndexOf<Test>, BenchmarkError> {
-        let proposal =
-            BoundedCallOf::<Test, ()>::Inline(BoundedVec::truncate_from(proposal_call.encode()));
-        let enactment_moment = frame_support::traits::schedule::DispatchTime::After(1);
-        Referenda::submit(
-            origin.clone(),
-            Box::new(proposal_origin),
-            proposal,
-            enactment_moment,
-        )?;
-        Referenda::place_decision_deposit(origin, 0)?;
-
-        System::set_block_number(2);
-        Referenda::nudge_referendum(RuntimeOrigin::root(), 0)?;
-
-        Ok(0)
-    }
-
-    fn finish_poll(index: PollIndexOf<Test>) -> Result<(), BenchmarkError> {
-        System::set_block_number(8);
-        Referenda::nudge_referendum(RuntimeOrigin::root(), index)?;
-
-        frame_support::assert_ok!(Referenda::ensure_ongoing(index));
-
-        System::set_block_number(9);
-        Referenda::nudge_referendum(RuntimeOrigin::root(), index)?;
-
-        frame_support::assert_err!(
-            Referenda::ensure_ongoing(index),
-            pallet_referenda::Error::<Test, ()>::NotOngoing
-        );
-
-        Ok(())
-    }
-}
-
-parameter_types! {
     pub const NoPay: Option<(Balance, AccountId, AccountId)> = None;
 }
+
 type RootCreatesCommunitiesForFree = EnsureRootWithSuccess<AccountId, NoPay>;
 type AnyoneElsePays = EnsureSignedPays<Test, ConstU64<10>, RootAccount>;
 
-pub type MembershipsManager = NonFungiblesMemberships<Nfts, pallet_nfts::ItemConfig>;
+parameter_types! {
+    pub const RootAccount: AccountId = AccountId::new([0xff; 32]);
+}
 
 impl Config for Test {
     type RuntimeFreezeReason = RuntimeFreezeReason;
@@ -478,8 +249,8 @@ impl Config for Test {
     type MemberMgmtOrigin = EnsureCommunity<Self>;
 
     type CommunityId = CommunityId;
-    type MembershipId = MembershipId;
-    type MemberMgmt = MembershipsManager;
+    type Hasher = BlakeTwo256;
+    type MaxMembers = ConstU32<100>;
 
     type Polls = Referenda;
     type Assets = Assets;
@@ -494,111 +265,38 @@ impl Config for Test {
 }
 
 pub const COMMUNITY: CommunityId = 1;
-pub const COMMUNITY_ORIGIN: OriginCaller =
-    OriginCaller::Communities(pallet_communities::Origin::<Test>::new(COMMUNITY));
 
-// Build genesis storage according to the mock runtime.
-pub fn new_test_ext(members: &[AccountId], memberships: &[MembershipId]) -> TestExternalities {
-    TestEnvBuilder::new()
-        .add_community(
-            COMMUNITY,
-            DecisionMethod::Membership,
-            members,
-            memberships,
-            None,
-        )
-        .build()
+pub fn community_origin(id: CommunityId) -> RuntimeOrigin {
+    pallet_communities::Origin::<Test>::new(id).into()
 }
 
-#[derive(Default)]
 pub(crate) struct TestEnvBuilder {
-    assets_config: AssetsConfig,
-    balances: Vec<(AccountId, Balance)>,
-    communities: Vec<CommunityId>,
-    decision_methods:
-        alloc::collections::btree_map::BTreeMap<CommunityId, DecisionMethod<AssetId, Balance>>,
+    communities: Vec<(CommunityId, PrivacyLevel)>,
     members: Vec<(CommunityId, AccountId)>,
-    memberships: Vec<(CommunityId, MembershipId)>,
-    tracks: Vec<(TrackIdOf<Test, ()>, TrackInfoOf<Test>)>,
 }
 
 impl TestEnvBuilder {
     pub(crate) fn new() -> Self {
-        Self::default()
+        Self {
+            communities: Vec::new(),
+            members: Vec::new(),
+        }
     }
 
-    pub(crate) fn add_asset(
-        mut self,
-        id: &AssetId,
-        owner: &AccountId,
-        is_sufficient: bool,
-        min_balance: Balance,
-        // name, symbol, decimals
-        maybe_metadata: Option<(Vec<u8>, Vec<u8>, u8)>,
-        maybe_accounts: Option<Vec<(AccountId, Balance)>>,
-    ) -> Self {
-        self.assets_config
-            .assets
-            .push((*id, owner.clone(), is_sufficient, min_balance));
-
-        if let Some((name, symbol, decimals)) = maybe_metadata {
-            self.assets_config
-                .metadata
-                .push((*id, name, symbol, decimals));
-        }
-
-        self.assets_config.accounts.append(
-            &mut maybe_accounts
-                .unwrap_or_default()
-                .into_iter()
-                .map(|(account_id, balance)| (*id, account_id, balance))
-                .collect(),
-        );
-
+    pub(crate) fn add_community(mut self, id: CommunityId, privacy: PrivacyLevel) -> Self {
+        self.communities.push((id, privacy));
         self
     }
 
-    pub(crate) fn add_community(
-        mut self,
-        community_id: CommunityId,
-        decision_method: DecisionMethod<AssetId, Balance>,
-        members: &[AccountId],
-        memberships: &[MembershipId],
-        maybe_track: Option<TrackInfoOf<Test>>,
-    ) -> Self {
-        self.communities.push(community_id);
-        self.decision_methods.insert(community_id, decision_method);
-        self.members.append(
-            &mut members
-                .iter()
-                .map(|m| (community_id, m.to_owned()))
-                .collect::<Vec<_>>(),
-        );
-        self.memberships.append(
-            &mut memberships
-                .iter()
-                .map(|m| (community_id, m.to_owned()))
-                .collect::<Vec<_>>(),
-        );
-        if let Some(track) = maybe_track {
-            self.tracks.push((community_id, track));
-        }
-
-        self
-    }
-
-    pub(crate) fn with_balances(mut self, balances: &[(AccountId, Balance)]) -> Self {
-        self.balances = balances.to_vec();
+    pub(crate) fn add_member(mut self, community_id: CommunityId, who: AccountId) -> Self {
+        self.members.push((community_id, who));
         self
     }
 
     pub(crate) fn build(self) -> TestExternalities {
         let t = RuntimeGenesisConfig {
-            assets: self.assets_config,
-            balances: pallet_balances::GenesisConfig {
-                balances: self.balances,
-                dev_accounts: None,
-            },
+            assets: Default::default(),
+            balances: Default::default(),
             system: Default::default(),
         }
         .build_storage()
@@ -609,107 +307,41 @@ impl TestEnvBuilder {
         ext.execute_with(|| {
             System::set_block_number(1);
 
-            Self::initialize_memberships_manager_collection().expect("collection is initialized");
-
-            for community_id in &self.communities {
-                Self::initialize_community_memberships_collection(community_id)
-                    .expect("collection is initialized");
-
-                let decision_method = self
-                    .decision_methods
-                    .get(community_id)
-                    .expect("should include decision_method on add_community");
-                let community_origin: RuntimeOrigin = Self::create_community_origin(community_id);
+            for (community_id, privacy) in &self.communities {
+                let origin = community_origin(*community_id);
 
                 Communities::create(
                     RuntimeOrigin::root(),
-                    community_origin.caller.clone(),
+                    origin.caller().clone(),
                     *community_id,
                 )
-                .expect("can add community");
+                .expect("can create community");
 
-                Communities::set_decision_method(
-                    community_origin.clone(),
-                    *community_id,
-                    decision_method.clone(),
-                )
-                .expect("can set decision info");
-
-                let mut members = self.members.iter().filter(|(cid, _)| cid == community_id);
-                let memberships = self
-                    .memberships
-                    .iter()
-                    .filter(|(cid, _)| cid == community_id);
-
-                assert!(
-                    self.memberships.len() >= self.members.len(),
-                    "there should be at least as many memberships as there are members"
-                );
-
-                for (_, membership) in memberships {
-                    use frame_support::traits::tokens::nonfungible_v2::Mutate;
-
-                    let account = Communities::community_account(community_id);
-                    MembershipCollection::mint_into(
-                        membership,
-                        &account,
-                        &Default::default(),
-                        true,
-                    )
-                    .expect("can mint membership");
-
-                    if let Some((_, who)) = members.next() {
-                        Communities::add_member(community_origin.clone(), who.clone())
-                            .expect("can add member");
-                    }
+                // Set the privacy level
+                if *privacy != PrivacyLevel::Public {
+                    crate::Info::<Test>::mutate(community_id, |info| {
+                        if let Some(ref mut info) = info {
+                            info.privacy = privacy.clone();
+                        }
+                    });
                 }
 
-                for (_, track_info) in self.tracks.iter().filter(|(cid, _)| cid == community_id) {
-                    Tracks::do_insert(
-                        *community_id,
-                        track_info.clone(),
-                        community_origin.caller.clone(),
+                for (cid, who) in self.members.iter().filter(|(cid, _)| cid == community_id) {
+                    Communities::add_member(
+                        community_origin(*cid),
+                        who.clone(),
+                        None,
+                        None,
                     )
-                    .expect("can add track");
+                    .expect("can add member");
                 }
             }
         });
 
         ext
     }
+}
 
-    pub(crate) fn initialize_memberships_manager_collection() -> DispatchResult {
-        Nfts::do_create_collection(
-            MembershipsManagerCollectionId::get(),
-            RootAccount::get(),
-            RootAccount::get(),
-            Default::default(),
-            0,
-            pallet_nfts::Event::ForceCreated {
-                collection: MembershipsManagerCollectionId::get(),
-                owner: RootAccount::get(),
-            },
-        )
-    }
-
-    pub(crate) fn initialize_community_memberships_collection(
-        community_id: &CommunityId,
-    ) -> DispatchResult {
-        let account = Communities::community_account(community_id);
-        Nfts::do_create_collection(
-            *community_id,
-            account.clone(),
-            account.clone(),
-            Default::default(),
-            0,
-            pallet_nfts::Event::ForceCreated {
-                collection: *community_id,
-                owner: account,
-            },
-        )
-    }
-
-    pub fn create_community_origin(community_id: &CommunityId) -> RuntimeOrigin {
-        pallet_communities::Origin::<Test>::new(*community_id).into()
-    }
+pub fn account(n: u8) -> AccountId {
+    AccountId::new([n; 32])
 }

--- a/pallets/communities/src/origin.rs
+++ b/pallets/communities/src/origin.rs
@@ -11,6 +11,7 @@ use frame_support::{
 use frame_system::EnsureSigned;
 #[cfg(feature = "xcm")]
 use sp_runtime::traits::TryConvert;
+use sp_core::H256;
 use sp_runtime::{morph_types, Permill};
 
 pub struct EnsureCommunity<T>(PhantomData<T>);
@@ -126,6 +127,10 @@ impl<T: Config> RawOrigin<T> {
 )]
 pub enum Subset<T: Config> {
     Member(AccountIdOf<T>),
+    AnonymousMember {
+        rank: GenericRank,
+        nullifier: H256,
+    },
     Members { count: u32 },
     Fraction(Permill),
     AtLeastRank(GenericRank),
@@ -160,6 +165,7 @@ where
         let part = match o.subset {
             None => BodyPart::Voice,
             Some(Subset::Member(_)) => BodyPart::Members { count: 1 },
+            Some(Subset::AnonymousMember { .. }) => return Err(()),
             Some(Subset::Members { count }) => BodyPart::Members { count },
             Some(Subset::Fraction(per)) => BodyPart::Fraction {
                 nom: per.deconstruct(),

--- a/pallets/communities/src/origin.rs
+++ b/pallets/communities/src/origin.rs
@@ -14,6 +14,13 @@ use sp_runtime::traits::TryConvert;
 use sp_core::H256;
 use sp_runtime::{morph_types, Permill};
 
+/// True when the subset variant represents an anonymous, unverified identity that must
+/// never authorize privileged actions. Used by admin/member-mgmt guards to reject
+/// anonymous origins.
+fn is_anonymous_subset<T: Config>(s: &Option<Subset<T>>) -> bool {
+    matches!(s, Some(Subset::AnonymousMember { .. }))
+}
+
 pub struct EnsureCommunity<T>(PhantomData<T>);
 
 impl<T> EnsureOrigin<RuntimeOriginFor<T>> for EnsureCommunity<T>
@@ -30,7 +37,12 @@ where
             return Err(o);
         }
         let id = match o.clone().into() {
-            Ok(RawOrigin { community_id, .. }) => community_id,
+            Ok(raw) => {
+                if is_anonymous_subset::<T>(&raw.subset) {
+                    return Err(o);
+                }
+                raw.community_id
+            }
             Err(_) => {
                 let origin = o.clone().into_caller();
                 CommunityIdFor::<T>::get(origin).ok_or_else(|| o.clone())?
@@ -213,7 +225,7 @@ where
     }
 }
 
-/// Ensure the origin is any `Signed` origin.
+/// Authorize a call as the community's keyless account. Rejects anonymous subsets.
 pub struct AsSignedByCommunity<T>(PhantomData<T>);
 impl<T, OuterOrigin> EnsureOrigin<OuterOrigin> for AsSignedByCommunity<T>
 where
@@ -228,9 +240,12 @@ where
     type Success = T::AccountId;
 
     fn try_origin(o: OuterOrigin) -> Result<Self::Success, OuterOrigin> {
-        match o.clone().into() {
-            Ok(RawOrigin { community_id, .. }) => Ok(Pallet::<T>::community_account(&community_id)),
-            _ => Err(o.clone()),
+        let converted: Result<RawOrigin<T>, OuterOrigin> = o.clone().into();
+        match converted {
+            Ok(raw) if !is_anonymous_subset::<T>(&raw.subset) => {
+                Ok(Pallet::<T>::community_account(&raw.community_id))
+            }
+            _ => Err(o),
         }
     }
 
@@ -242,7 +257,8 @@ where
     }
 }
 
-/// Ensure the origin is any `Signed` origin.
+/// Authorize a call as the community's keyless account for a fixed community id.
+/// Rejects anonymous subsets.
 pub struct AsSignedByStaticCommunity<T, C>(PhantomData<(T, C)>);
 impl<T, C, OuterOrigin> EnsureOrigin<OuterOrigin> for AsSignedByStaticCommunity<T, C>
 where
@@ -258,11 +274,15 @@ where
     type Success = T::AccountId;
 
     fn try_origin(o: OuterOrigin) -> Result<Self::Success, OuterOrigin> {
-        match o.clone().into() {
+        let converted: Result<RawOrigin<T>, OuterOrigin> = o.clone().into();
+        match converted {
             Ok(RawOrigin {
-                ref community_id, ..
-            }) if community_id == &C::get() => Ok(Pallet::<T>::community_account(community_id)),
-            _ => Err(o.clone()),
+                ref community_id,
+                ref subset,
+            }) if community_id == &C::get() && !is_anonymous_subset::<T>(subset) => {
+                Ok(Pallet::<T>::community_account(community_id))
+            }
+            _ => Err(o),
         }
     }
 
@@ -271,5 +291,40 @@ where
         use crate::BenchmarkHelper;
         let community_id = T::BenchmarkHelper::community_id();
         Ok(frame_system::RawOrigin::Signed(Pallet::<T>::community_account(&community_id)).into())
+    }
+}
+
+/// Extracts a community id from an AnonymousMember origin — the only privilege granted to
+/// anonymous callers. Rejects every other origin variant. Voting extrinsics use this
+/// (instead of `EnsureCommunity`) to accept anonymous origins, so a proof of membership
+/// cannot be used to dispatch admin or member-management actions.
+pub struct EnsureAnonymousVoter<T>(PhantomData<T>);
+impl<T> EnsureOrigin<RuntimeOriginFor<T>> for EnsureAnonymousVoter<T>
+where
+    RuntimeOriginFor<T>:
+        OriginTrait + Into<Result<RawOrigin<T>, RuntimeOriginFor<T>>> + From<RawOrigin<T>>,
+    T: Config,
+{
+    type Success = (CommunityIdOf<T>, H256);
+
+    fn try_origin(o: RuntimeOriginFor<T>) -> Result<Self::Success, RuntimeOriginFor<T>> {
+        match o.clone().into() {
+            Ok(raw) => match raw.subset {
+                Some(Subset::AnonymousMember { nullifier, .. }) => Ok((raw.community_id, nullifier)),
+                _ => Err(o),
+            },
+            Err(_) => Err(o),
+        }
+    }
+
+    #[cfg(feature = "runtime-benchmarks")]
+    fn try_successful_origin() -> Result<RuntimeOriginFor<T>, ()> {
+        use crate::BenchmarkHelper;
+        let mut raw = RawOrigin::<T>::new(T::BenchmarkHelper::community_id());
+        raw.with_subset(Subset::AnonymousMember {
+            rank: GenericRank::default(),
+            nullifier: H256::zero(),
+        });
+        Ok(raw.into())
     }
 }

--- a/pallets/communities/src/origin.rs
+++ b/pallets/communities/src/origin.rs
@@ -74,14 +74,12 @@ where
         o: RuntimeOriginFor<T>,
         community_id: &CommunityIdOf<T>,
     ) -> Result<Self::Success, RuntimeOriginFor<T>> {
-        use frame_system::RawOrigin::Signed;
-
-        match o.clone().into() {
-            Ok(Signed(who)) => {
-                if Pallet::<T>::is_member(community_id, &who) {
+        match o.as_system_ref() {
+            Some(frame_system::RawOrigin::Signed(who)) => {
+                if Pallet::<T>::is_member(community_id, who) {
                     Ok(())
                 } else {
-                    Err(o.clone())
+                    Err(o)
                 }
             }
             _ => Err(o),
@@ -118,6 +116,10 @@ impl<T: Config> RawOrigin<T> {
 
     pub fn id(&self) -> CommunityIdOf<T> {
         self.community_id
+    }
+
+    pub fn subset(&self) -> Option<&Subset<T>> {
+        self.subset.as_ref()
     }
 }
 

--- a/pallets/communities/src/origin.rs
+++ b/pallets/communities/src/origin.rs
@@ -1,9 +1,9 @@
 use crate::{
-    types::{CommunityIdOf, CommunityState::Active, MembershipIdOf, RuntimeOriginFor},
+    types::{CommunityIdOf, CommunityState::Active, RuntimeOriginFor},
     AccountIdOf, CommunityIdFor, Config, Info, Pallet,
 };
 use core::marker::PhantomData;
-use frame_contrib_traits::memberships::{GenericRank, Inspect};
+use frame_contrib_traits::memberships::GenericRank;
 use frame_support::{
     pallet_prelude::*,
     traits::{EnsureOriginWithArg, MapSuccess, OriginTrait},
@@ -77,7 +77,7 @@ where
 
         match o.clone().into() {
             Ok(Signed(who)) => {
-                if T::MemberMgmt::is_member_of(community_id, &who) {
+                if Pallet::<T>::is_member(community_id, &who) {
                     Ok(())
                 } else {
                     Err(o.clone())
@@ -125,7 +125,7 @@ impl<T: Config> RawOrigin<T> {
     Clone, Debug, Decode, DecodeWithMemTracking, Encode, Eq, MaxEncodedLen, PartialEq, TypeInfo,
 )]
 pub enum Subset<T: Config> {
-    Member(MembershipIdOf<T>),
+    Member(AccountIdOf<T>),
     Members { count: u32 },
     Fraction(Permill),
     AtLeastRank(GenericRank),

--- a/pallets/communities/src/tests/mod.rs
+++ b/pallets/communities/src/tests/mod.rs
@@ -627,7 +627,11 @@ fn test_anonymous_vote_uses_nullifier_key() {
 }
 
 #[test]
-fn test_anonymous_vote_with_rank() {
+fn test_anonymous_vote_rejects_rank_weighted_decision() {
+    // Rank-weighted voting cannot be authorized anonymously: the merkle proof doesn't
+    // bind the leaf's rank, so the multiplier would be user-chosen and forgeable.
+    // Only flat `Membership` voting is allowed on the anonymous path until a ZK backend
+    // makes rank a verified public input. (Issue C2 from review.)
     let alice = account(1);
 
     TestEnvBuilder::new()
@@ -635,26 +639,42 @@ fn test_anonymous_vote_with_rank() {
         .add_member(COMMUNITY, alice.clone())
         .build()
         .execute_with(|| {
-            // Set decision method to Rank
             CommunityDecisionMethod::<Test>::set(COMMUNITY, DecisionMethod::Rank);
 
             let poll_index = setup_poll(COMMUNITY);
             let nullifier = H256::from_low_u64_be(100);
-            let rank = GenericRank::from(3u8);
 
-            let origin = anon_origin(COMMUNITY, rank, nullifier);
-            assert_ok!(Communities::vote(
-                origin,
-                poll_index,
-                Vote::Standard(true),
-            ));
+            let origin = anon_origin(COMMUNITY, GenericRank::from(3u8), nullifier);
+            assert_noop!(
+                Communities::vote(origin, poll_index, Vote::Standard(true)),
+                Error::InvalidVoteType,
+            );
+        });
+}
 
-            // Verify the multiplied weight reflects rank
+#[test]
+fn test_anonymous_vote_rank_from_origin_is_ignored() {
+    // Even when a synthesised anonymous origin carries a high rank, the vote weight
+    // is always 1 under DecisionMethod::Membership. (Issue C2 from review.)
+    let alice = account(1);
+
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .add_member(COMMUNITY, alice.clone())
+        .build()
+        .execute_with(|| {
+            let poll_index = setup_poll(COMMUNITY);
+            let nullifier = H256::from_low_u64_be(777);
+
+            // A caller who managed to construct an AnonymousMember origin directly with
+            // rank=100 still gets weight 1 — the pallet ignores the origin's rank field.
+            let origin = anon_origin(COMMUNITY, GenericRank::from(100u8), nullifier);
+            assert_ok!(Communities::vote(origin, poll_index, Vote::Standard(true)));
+
             let voter_key = BlakeTwo256::hash_of(&nullifier);
             let (_, multiplied) = CommunityVotes::<Test>::get(poll_index, &voter_key)
                 .expect("vote should be stored");
-            // rank 3 * vote weight 1 = 3
-            assert_eq!(multiplied, 3);
+            assert_eq!(multiplied, 1, "anonymous vote must be rank-1 regardless of origin rank");
         });
 }
 
@@ -706,7 +726,7 @@ fn test_anonymous_vote_duplicate_nullifier_rejected() {
                 Vote::Standard(true),
             ));
 
-            // Second anonymous vote with same nullifier should fail (AlreadyOngoing)
+            // Second anonymous vote with same nullifier should fail.
             let origin2 = anon_origin(COMMUNITY, GenericRank::default(), nullifier);
             assert_noop!(
                 Communities::vote(
@@ -714,7 +734,7 @@ fn test_anonymous_vote_duplicate_nullifier_rejected() {
                     poll_index,
                     Vote::Standard(false),
                 ),
-                Error::AlreadyOngoing
+                Error::AnonymousVoteAlreadyCast
             );
         });
 }
@@ -760,4 +780,136 @@ fn test_anonymous_vote_different_nullifiers_both_counted() {
             assert_eq!(tally.nays, 1);
             assert_eq!(tally.bare_ayes, 1);
         });
+}
+
+// ---- Adversarial tests for the critical issues flagged in the review ----
+//
+// These tests target the escalation paths the merkle-only MVP previously allowed.
+// If any of them regresses in the future, the anonymous membership scheme is unsound
+// again — treat failures as security regressions, not flakes.
+
+#[test]
+fn test_c1_anonymous_origin_cannot_manage_members() {
+    // An anonymous community origin must NOT be accepted by `MemberMgmtOrigin`.
+    // Before the C1 fix, `EnsureCommunity` destructured `RawOrigin { community_id, .. }`
+    // and ignored the subset, so any caller with a valid merkle proof could
+    // suspend/remove/promote/demote anyone in the community.
+    let alice = account(1);
+    let bob = account(2);
+
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .add_member(COMMUNITY, alice.clone())
+        .add_member(COMMUNITY, bob.clone())
+        .build()
+        .execute_with(|| {
+            let anon = anon_origin(COMMUNITY, GenericRank::default(), H256::from_low_u64_be(1));
+
+            // Every member-management call must reject the anonymous origin with BadOrigin.
+            assert_noop!(
+                Communities::suspend_member(anon.clone(), bob.clone()),
+                sp_runtime::DispatchError::BadOrigin
+            );
+            assert_noop!(
+                Communities::remove_member(anon.clone(), bob.clone()),
+                sp_runtime::DispatchError::BadOrigin
+            );
+            assert_noop!(
+                Communities::promote(anon.clone(), bob.clone()),
+                sp_runtime::DispatchError::BadOrigin
+            );
+            assert_noop!(
+                Communities::demote(anon.clone(), bob.clone()),
+                sp_runtime::DispatchError::BadOrigin
+            );
+            assert_noop!(
+                Communities::add_member(anon.clone(), account(42), None, None),
+                sp_runtime::DispatchError::BadOrigin
+            );
+
+            // Bob must still be an active member — no state was mutated.
+            assert!(Members::<Test>::get(COMMUNITY, &bob).is_some());
+            assert_eq!(
+                Members::<Test>::get(COMMUNITY, &bob).unwrap().status,
+                MemberStatus::Active,
+            );
+        });
+}
+
+#[test]
+fn test_c1_anonymous_origin_cannot_call_admin_functions() {
+    // The same escalation route also guarded admin-only functions via `AdminOrigin`.
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .build()
+        .execute_with(|| {
+            let anon = anon_origin(COMMUNITY, GenericRank::default(), H256::from_low_u64_be(2));
+            let fake_root = BlakeTwo256::hash_of(b"whatever");
+
+            assert_noop!(
+                Communities::update_membership_root(anon.clone(), fake_root, 0),
+                sp_runtime::DispatchError::BadOrigin
+            );
+            assert_noop!(
+                Communities::update_sub_root(anon.clone(), 1, fake_root),
+                sp_runtime::DispatchError::BadOrigin
+            );
+            assert_noop!(
+                Communities::set_budget(anon.clone(), 1_000_000, 100),
+                sp_runtime::DispatchError::BadOrigin
+            );
+            assert_noop!(
+                Communities::set_decision_method(anon, COMMUNITY, DecisionMethod::Membership),
+                sp_runtime::DispatchError::BadOrigin
+            );
+        });
+}
+
+#[test]
+fn test_c1_anonymous_origin_cannot_dispatch_as_account() {
+    // The most damaging escalation: dispatching as the community's keyless account
+    // would allow draining the treasury. `MemberMgmtOrigin` must reject anonymous.
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .build()
+        .execute_with(|| {
+            let anon = anon_origin(COMMUNITY, GenericRank::default(), H256::from_low_u64_be(3));
+            // Any inner call works here; we're asserting the outer origin check rejects.
+            let inner: RuntimeCall = crate::Call::<Test>::set_decision_method {
+                community_id: COMMUNITY,
+                decision_method: DecisionMethod::Membership,
+            }
+            .into();
+            assert_noop!(
+                Communities::dispatch_as_account(anon, Box::new(inner)),
+                sp_runtime::DispatchError::BadOrigin
+            );
+        });
+}
+
+#[test]
+fn test_c4_action_scope_derived_from_call() {
+    // The extension must derive the nullifier's action-scope from the dispatched call,
+    // not accept it from the caller. Same caller, same leaf, different call should
+    // produce different nullifiers. We validate by exercising the same hashing the
+    // extension would use and asserting the nullifiers differ.
+    use codec::Encode;
+
+    let call_a: RuntimeCall = crate::Call::<Test>::vote {
+        poll_index: 0,
+        vote: Vote::Standard(true),
+    }
+    .into();
+    let call_b: RuntimeCall = crate::Call::<Test>::vote {
+        poll_index: 1,
+        vote: Vote::Standard(true),
+    }
+    .into();
+
+    let scope_a: H256 = sp_io::hashing::blake2_256(&call_a.encode()).into();
+    let scope_b: H256 = sp_io::hashing::blake2_256(&call_b.encode()).into();
+    assert_ne!(
+        scope_a, scope_b,
+        "different calls must produce different action scopes"
+    );
 }

--- a/pallets/communities/src/tests/mod.rs
+++ b/pallets/communities/src/tests/mod.rs
@@ -6,7 +6,9 @@ use sp_core::H256;
 
 use crate::mock::*;
 use crate::types::*;
+use crate::verifier::{MembershipInputs, MerkleProof};
 use crate::{Budget, CommunityDecisionMethod, CommunityVotes, MemberCount, Members, MerkleRoot, SubRoots, RanksTotal, UsedNullifiers};
+use fc_traits_proof_verifier::ProofVerifier;
 
 type Error = crate::Error<Test>;
 
@@ -379,34 +381,47 @@ fn test_anonymous_membership_proof_validation() {
             let alice_index = leaves.iter().position(|l| l == &alice_leaf).expect("alice leaf in tree");
 
             // Generate merkle proof
-            let proof = binary_merkle_tree::merkle_proof::<BlakeTwo256, _, _>(
+            let bmt_proof = binary_merkle_tree::merkle_proof::<BlakeTwo256, _, _>(
                 leaves.iter().map(|l| l.as_ref()),
                 alice_index as u32,
             );
 
             // The proof root should match the stored root
-            assert_eq!(proof.root, root, "proof root must match stored root");
+            assert_eq!(bmt_proof.root, root, "proof root must match stored root");
 
-            // Verify the proof
-            let valid = binary_merkle_tree::verify_proof::<BlakeTwo256, _, _>(
-                &root,
-                proof.proof.clone(),
-                proof.number_of_leaves,
-                proof.leaf_index,
-                &alice_leaf,
+            // Verify valid proof via the ProofVerifier trait
+            let proof = MerkleProof::<BlakeTwo256> {
+                leaf: alice_leaf,
+                siblings: bmt_proof.proof.clone(),
+                leaf_index: bmt_proof.leaf_index as u32,
+                leaf_count: bmt_proof.number_of_leaves as u32,
+            };
+            let public_inputs = MembershipInputs::<BlakeTwo256> { root };
+            assert!(
+                <crate::verifier::MerkleVerifier<BlakeTwo256> as ProofVerifier>::verify(
+                    &(),
+                    &proof,
+                    &public_inputs,
+                ).is_ok(),
+                "merkle proof should be valid for alice",
             );
-            assert!(valid, "merkle proof should be valid for alice");
 
             // Verify with wrong leaf should fail
             let wrong_leaf = BlakeTwo256::hash_of(b"wrong");
-            let invalid = binary_merkle_tree::verify_proof::<BlakeTwo256, _, _>(
-                &root,
-                proof.proof,
-                proof.number_of_leaves,
-                proof.leaf_index,
-                &wrong_leaf,
+            let bad_proof = MerkleProof::<BlakeTwo256> {
+                leaf: wrong_leaf,
+                siblings: bmt_proof.proof,
+                leaf_index: bmt_proof.leaf_index as u32,
+                leaf_count: bmt_proof.number_of_leaves as u32,
+            };
+            assert!(
+                <crate::verifier::MerkleVerifier<BlakeTwo256> as ProofVerifier>::verify(
+                    &(),
+                    &bad_proof,
+                    &public_inputs,
+                ).is_err(),
+                "merkle proof should be invalid for wrong leaf",
             );
-            assert!(!invalid, "merkle proof should be invalid for wrong leaf");
         });
 }
 

--- a/pallets/communities/src/tests/mod.rs
+++ b/pallets/communities/src/tests/mod.rs
@@ -936,6 +936,153 @@ fn test_c1_anonymous_origin_cannot_dispatch_as_account() {
 }
 
 #[test]
+fn test_m3_member_role_enforced_on_signed_caller() {
+    // A signed account that is only a plain Member must not be able to use the
+    // member-management extrinsics even if they pass the configured MemberMgmtOrigin.
+    let alice = account(1); // plain Member
+    let bob = account(2);
+
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .build()
+        .execute_with(|| {
+            let cmty = community_origin(COMMUNITY);
+            assert_ok!(Communities::add_member(
+                cmty.clone(),
+                alice.clone(),
+                None,
+                None,
+            ));
+            assert_ok!(Communities::add_member(
+                cmty.clone(),
+                bob.clone(),
+                None,
+                None,
+            ));
+            // Hook alice's signed origin into the mgmt guard by registering her as the
+            // community's admin origin caller in CommunityIdFor.
+            let alice_origin = RuntimeOrigin::signed(alice.clone());
+            use frame_support::traits::OriginTrait;
+            crate::CommunityIdFor::<Test>::insert(alice_origin.caller().clone(), COMMUNITY);
+
+            // The role check must block a plain-Member caller from suspending someone.
+            assert_noop!(
+                Communities::suspend_member(alice_origin, bob.clone()),
+                Error::NotAuthorized,
+            );
+        });
+}
+
+#[test]
+fn test_m3_manager_role_can_manage_members() {
+    let manager = account(1);
+    let bob = account(2);
+
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .build()
+        .execute_with(|| {
+            let cmty = community_origin(COMMUNITY);
+            assert_ok!(Communities::add_member(
+                cmty.clone(),
+                manager.clone(),
+                None,
+                Some(Role::Manager),
+            ));
+            assert_ok!(Communities::add_member(cmty, bob.clone(), None, None));
+
+            let mgr_origin = RuntimeOrigin::signed(manager.clone());
+            use frame_support::traits::OriginTrait;
+            crate::CommunityIdFor::<Test>::insert(mgr_origin.caller().clone(), COMMUNITY);
+
+            assert_ok!(Communities::suspend_member(mgr_origin, bob.clone()));
+            assert_eq!(
+                Members::<Test>::get(COMMUNITY, &bob).unwrap().status,
+                MemberStatus::Suspended,
+            );
+        });
+}
+
+#[test]
+fn test_m8_prune_vote_removes_stale_entry() {
+    let voter_key = BlakeTwo256::hash_of(&account(7));
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .build()
+        .execute_with(|| {
+            // Poll index 999 does not exist (no setup_poll), so Polls::as_ongoing returns
+            // None — mimicking a finished/purged poll.
+            let stored: (VoteOf<Test>, VoteWeight) = (Vote::Standard(true), 1);
+            CommunityVotes::<Test>::insert(999u32, &voter_key, stored);
+
+            // Pruning must be permissionless for ended polls.
+            let random = account(123);
+            assert_ok!(Communities::prune_vote(
+                RuntimeOrigin::signed(random),
+                999,
+                voter_key,
+            ));
+            assert!(CommunityVotes::<Test>::get(999u32, &voter_key).is_none());
+        });
+}
+
+#[test]
+fn test_m8_prune_vote_rejected_while_poll_ongoing() {
+    let alice = account(1);
+
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .add_member(COMMUNITY, alice.clone())
+        .build()
+        .execute_with(|| {
+            let poll_index = setup_poll(COMMUNITY);
+            assert_ok!(Communities::vote(
+                RuntimeOrigin::signed(alice.clone()),
+                poll_index,
+                Vote::Standard(true),
+            ));
+            let voter_key = BlakeTwo256::hash_of(&alice);
+            assert_noop!(
+                Communities::prune_vote(
+                    RuntimeOrigin::signed(account(99)),
+                    poll_index,
+                    voter_key,
+                ),
+                Error::AlreadyOngoing,
+            );
+        });
+}
+
+#[test]
+fn test_m9_remove_sub_root() {
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Private)
+        .build()
+        .execute_with(|| {
+            let origin = community_origin(COMMUNITY);
+            let root = BlakeTwo256::hash_of(b"x");
+            assert_ok!(Communities::update_sub_root(origin.clone(), 7, root));
+            assert_eq!(SubRoots::<Test>::get(COMMUNITY, 7), Some(root));
+            assert_ok!(Communities::remove_sub_root(origin, 7));
+            assert!(SubRoots::<Test>::get(COMMUNITY, 7).is_none());
+        });
+}
+
+#[test]
+fn test_set_budget_rejects_zero_session_length() {
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .build()
+        .execute_with(|| {
+            let origin = community_origin(COMMUNITY);
+            assert_noop!(
+                Communities::set_budget(origin, 1000, 0),
+                Error::InvalidBudget,
+            );
+        });
+}
+
+#[test]
 fn test_c4_action_scope_derived_from_call() {
     // The extension must derive the nullifier's action-scope from the dispatched call,
     // not accept it from the caller. Same caller, same leaf, different call should

--- a/pallets/communities/src/tests/mod.rs
+++ b/pallets/communities/src/tests/mod.rs
@@ -1,11 +1,11 @@
 use frame_support::{assert_noop, assert_ok};
-use sp_runtime::traits::BlakeTwo256;
+use sp_runtime::traits::{BlakeTwo256, Hash as _};
 
 use frame_contrib_traits::memberships::GenericRank;
 
 use crate::mock::*;
 use crate::types::*;
-use crate::{Budget, MemberCount, Members, MerkleRoot, SubRoots, RanksTotal};
+use crate::{Budget, MemberCount, Members, MerkleRoot, SubRoots, RanksTotal, UsedNullifiers};
 
 type Error = crate::Error<Test>;
 
@@ -342,5 +342,106 @@ fn test_budget_exhaustion() {
 
             // Check on community without budget should also fail
             assert!(Communities::check_budget(&999, 1).is_err());
+        });
+}
+
+#[test]
+fn test_anonymous_membership_proof_validation() {
+    let alice = account(1);
+    let bob = account(2);
+    let charlie = account(3);
+
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .add_member(COMMUNITY, alice.clone())
+        .add_member(COMMUNITY, bob.clone())
+        .add_member(COMMUNITY, charlie.clone())
+        .build()
+        .execute_with(|| {
+            // The merkle root should be set
+            let root = MerkleRoot::<Test>::get(COMMUNITY).expect("root should exist");
+
+            // Compute the leaves the same way recompute_merkle_root does
+            let mut leaves: alloc::vec::Vec<sp_core::H256> =
+                Members::<Test>::iter_prefix(COMMUNITY)
+                    .filter(|(_, record)| record.status == MemberStatus::Active)
+                    .map(|(who, record)| {
+                        BlakeTwo256::hash_of(&(who, COMMUNITY, record.rank, record.nonce))
+                    })
+                    .collect();
+            leaves.sort();
+
+            // Find alice's leaf
+            let alice_record = Members::<Test>::get(COMMUNITY, &alice).unwrap();
+            let alice_leaf =
+                BlakeTwo256::hash_of(&(alice.clone(), COMMUNITY, alice_record.rank, alice_record.nonce));
+            let alice_index = leaves.iter().position(|l| l == &alice_leaf).expect("alice leaf in tree");
+
+            // Generate merkle proof
+            let proof = binary_merkle_tree::merkle_proof::<BlakeTwo256, _, _>(
+                leaves.iter().map(|l| l.as_ref()),
+                alice_index as u32,
+            );
+
+            // The proof root should match the stored root
+            assert_eq!(proof.root, root, "proof root must match stored root");
+
+            // Verify the proof
+            let valid = binary_merkle_tree::verify_proof::<BlakeTwo256, _, _>(
+                &root,
+                proof.proof.clone(),
+                proof.number_of_leaves,
+                proof.leaf_index,
+                &alice_leaf,
+            );
+            assert!(valid, "merkle proof should be valid for alice");
+
+            // Verify with wrong leaf should fail
+            let wrong_leaf = BlakeTwo256::hash_of(b"wrong");
+            let invalid = binary_merkle_tree::verify_proof::<BlakeTwo256, _, _>(
+                &root,
+                proof.proof,
+                proof.number_of_leaves,
+                proof.leaf_index,
+                &wrong_leaf,
+            );
+            assert!(!invalid, "merkle proof should be invalid for wrong leaf");
+        });
+}
+
+#[test]
+fn test_nullifier_prevents_replay() {
+    use sp_core::H256;
+
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .build()
+        .execute_with(|| {
+            let action_scope = H256::from([0xAA; 32]);
+            let nullifier = H256::from([0xBB; 32]);
+
+            // Initially the nullifier should not exist
+            assert!(
+                !UsedNullifiers::<Test>::contains_key((&COMMUNITY, &action_scope, &nullifier))
+            );
+
+            // Insert the nullifier
+            UsedNullifiers::<Test>::insert((&COMMUNITY, &action_scope, &nullifier), ());
+
+            // Now it should be detected
+            assert!(
+                UsedNullifiers::<Test>::contains_key((&COMMUNITY, &action_scope, &nullifier))
+            );
+
+            // A different action_scope should not be affected
+            let other_scope = H256::from([0xCC; 32]);
+            assert!(
+                !UsedNullifiers::<Test>::contains_key((&COMMUNITY, &other_scope, &nullifier))
+            );
+
+            // A different community should not be affected
+            assert!(
+                !UsedNullifiers::<Test>::contains_key((&999u32, &action_scope, &nullifier))
+            );
         });
 }

--- a/pallets/communities/src/tests/mod.rs
+++ b/pallets/communities/src/tests/mod.rs
@@ -5,7 +5,7 @@ use frame_contrib_traits::memberships::GenericRank;
 
 use crate::mock::*;
 use crate::types::*;
-use crate::{MemberCount, Members, MerkleRoot, SubRoots, RanksTotal};
+use crate::{Budget, MemberCount, Members, MerkleRoot, SubRoots, RanksTotal};
 
 type Error = crate::Error<Test>;
 
@@ -242,5 +242,105 @@ fn test_promote_demote_updates_merkle_root() {
             assert_ne!(root_after_promote, root_after_demote);
             // After demote back to 0, should match original root
             assert_eq!(root_before, root_after_demote);
+        });
+}
+
+#[test]
+fn test_set_budget() {
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .build()
+        .execute_with(|| {
+            let origin = community_origin(COMMUNITY);
+
+            assert_ok!(Communities::set_budget(origin.clone(), 1000, 100));
+
+            let budget = Budget::<Test>::get(COMMUNITY).expect("budget should exist");
+            assert_eq!(budget.capacity, 1000);
+            assert_eq!(budget.used, 0);
+            assert_eq!(budget.session_length, 100);
+            assert_eq!(budget.session_start, 1); // block 1 from test setup
+        });
+}
+
+#[test]
+fn test_budget_check_and_burn() {
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .build()
+        .execute_with(|| {
+            let origin = community_origin(COMMUNITY);
+
+            assert_ok!(Communities::set_budget(origin.clone(), 1000, 100));
+
+            // Check budget available
+            let remaining = Communities::check_budget(&COMMUNITY, 200).expect("should have budget");
+            assert_eq!(remaining, 800);
+
+            // Burn some budget
+            Communities::burn_budget(&COMMUNITY, 300);
+            let budget = Budget::<Test>::get(COMMUNITY).unwrap();
+            assert_eq!(budget.used, 300);
+
+            // Check again with reduced budget
+            let remaining = Communities::check_budget(&COMMUNITY, 200).expect("should have budget");
+            assert_eq!(remaining, 500);
+
+            // Refund some
+            Communities::refund_budget(&COMMUNITY, 100);
+            let budget = Budget::<Test>::get(COMMUNITY).unwrap();
+            assert_eq!(budget.used, 200);
+        });
+}
+
+#[test]
+fn test_budget_session_reset() {
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .build()
+        .execute_with(|| {
+            let origin = community_origin(COMMUNITY);
+
+            // Set budget at block 1 with session length 10
+            assert_ok!(Communities::set_budget(origin.clone(), 1000, 10));
+
+            // Burn some budget
+            Communities::burn_budget(&COMMUNITY, 500);
+            assert_eq!(Budget::<Test>::get(COMMUNITY).unwrap().used, 500);
+
+            // Advance past session end (block 1 + 10 = 11)
+            frame_system::Pallet::<Test>::set_block_number(11);
+
+            // check_budget should reset the session
+            let remaining = Communities::check_budget(&COMMUNITY, 100).expect("should have budget");
+            assert_eq!(remaining, 900); // full capacity minus cost
+
+            // burn_budget should also reset the session
+            frame_system::Pallet::<Test>::set_block_number(22);
+            Communities::burn_budget(&COMMUNITY, 200);
+            let budget = Budget::<Test>::get(COMMUNITY).unwrap();
+            assert_eq!(budget.used, 200);
+            assert_eq!(budget.session_start, 22);
+        });
+}
+
+#[test]
+fn test_budget_exhaustion() {
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .build()
+        .execute_with(|| {
+            let origin = community_origin(COMMUNITY);
+
+            assert_ok!(Communities::set_budget(origin.clone(), 100, 50));
+
+            // Burn all budget
+            Communities::burn_budget(&COMMUNITY, 100);
+
+            // Check should fail
+            assert!(Communities::check_budget(&COMMUNITY, 1).is_err());
+
+            // Check on community without budget should also fail
+            assert!(Communities::check_budget(&999, 1).is_err());
         });
 }

--- a/pallets/communities/src/tests/mod.rs
+++ b/pallets/communities/src/tests/mod.rs
@@ -7,7 +7,7 @@ use sp_core::H256;
 use crate::mock::*;
 use crate::types::*;
 use crate::verifier::{MembershipInputs, MerkleProof};
-use crate::{Budget, CommunityDecisionMethod, CommunityVotes, MemberCount, Members, MerkleRoot, SubRoots, RanksTotal, UsedNullifiers};
+use crate::{Budget, ClaimedSupport, CommunityDecisionMethod, CommunityVotes, MemberCount, Members, MerkleRoot, SubRoots, RanksTotal, UsedNullifiers};
 use fc_traits_proof_verifier::ProofVerifier;
 
 type Error = crate::Error<Test>;
@@ -159,7 +159,55 @@ fn test_private_community_root_update() {
             ));
 
             assert_eq!(MerkleRoot::<Test>::get(COMMUNITY), Some(fake_root));
-            assert_eq!(MemberCount::<Test>::get(COMMUNITY), 42);
+            // H3 fix: the admin-supplied number lands in ClaimedSupport, not MemberCount.
+            assert_eq!(ClaimedSupport::<Test>::get(COMMUNITY), 42);
+            assert_eq!(
+                MemberCount::<Test>::get(COMMUNITY),
+                0,
+                "MemberCount must not be writable by update_membership_root"
+            );
+        });
+}
+
+#[test]
+fn test_m2_suspend_clears_root_on_private_community() {
+    // Without this, a suspended member's old merkle proof remains valid against the
+    // stale root until the admin manually republishes. Fail-closed: clear the root on
+    // any on-chain membership change for Private/Hybrid communities so the extension
+    // rejects proofs with NO_MEMBERSHIP_ROOT until the admin republishes.
+    let alice = account(1);
+
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Hybrid)
+        .build()
+        .execute_with(|| {
+            let origin = community_origin(COMMUNITY);
+            // Seed a member on-chain so we have something to suspend.
+            crate::Members::<Test>::insert(
+                COMMUNITY,
+                &alice,
+                MemberRecord {
+                    rank: GenericRank::default(),
+                    role: Role::Member,
+                    ..Default::default()
+                },
+            );
+            MemberCount::<Test>::insert(COMMUNITY, 1);
+
+            let published_root =
+                <BlakeTwo256 as sp_runtime::traits::Hash>::hash_of(b"off-chain tree");
+            assert_ok!(Communities::update_membership_root(
+                origin.clone(),
+                published_root,
+                100,
+            ));
+            assert_eq!(MerkleRoot::<Test>::get(COMMUNITY), Some(published_root));
+
+            assert_ok!(Communities::suspend_member(origin.clone(), alice.clone()));
+            assert!(
+                MerkleRoot::<Test>::get(COMMUNITY).is_none(),
+                "on-chain suspension must invalidate the published root until admin republishes"
+            );
         });
 }
 

--- a/pallets/communities/src/tests/mod.rs
+++ b/pallets/communities/src/tests/mod.rs
@@ -1,11 +1,12 @@
-use frame_support::{assert_noop, assert_ok};
+use frame_support::{assert_noop, assert_ok, traits::Hooks};
 use sp_runtime::traits::{BlakeTwo256, Hash as _};
 
 use frame_contrib_traits::memberships::GenericRank;
+use sp_core::H256;
 
 use crate::mock::*;
 use crate::types::*;
-use crate::{Budget, MemberCount, Members, MerkleRoot, SubRoots, RanksTotal, UsedNullifiers};
+use crate::{Budget, CommunityDecisionMethod, CommunityVotes, MemberCount, Members, MerkleRoot, SubRoots, RanksTotal, UsedNullifiers};
 
 type Error = crate::Error<Test>;
 
@@ -443,5 +444,305 @@ fn test_nullifier_prevents_replay() {
             assert!(
                 !UsedNullifiers::<Test>::contains_key((&999u32, &action_scope, &nullifier))
             );
+        });
+}
+
+// Helper to create a track, submit a referendum, and advance to decision phase
+fn setup_poll(community_id: CommunityId) -> u32 {
+    use codec::Encode;
+    use frame_support::traits::OriginTrait;
+    use fc_pallet_referenda_tracks::SplitId;
+    use pallet_referenda::{BoundedCallOf, Curve, TrackInfo, TrackInfoOf};
+    use sp_runtime::{str_array as s, BoundedVec, Perbill};
+
+    let track_info: TrackInfoOf<Test> = TrackInfo {
+        name: s("Community"),
+        max_deciding: 1,
+        decision_deposit: 5,
+        prepare_period: 1,
+        decision_period: 5,
+        confirm_period: 1,
+        min_enactment_period: 1,
+        min_approval: Curve::LinearDecreasing {
+            length: Perbill::from_percent(100),
+            floor: Perbill::from_percent(50),
+            ceil: Perbill::from_percent(100),
+        },
+        min_support: Curve::LinearDecreasing {
+            length: Perbill::from_percent(100),
+            floor: Perbill::from_percent(0),
+            ceil: Perbill::from_percent(100),
+        },
+    };
+
+    let community_origin_caller = community_origin(community_id).caller().clone();
+
+    // Directly insert track storage for the exact track_id = community_id
+    let track_id: CommunityId = community_id;
+    let (group, sub_track) = track_id.split();
+
+    fc_pallet_referenda_tracks::TracksIds::<Test, ()>::try_mutate(|ids| ids.try_insert(track_id))
+        .expect("can insert track id");
+    fc_pallet_referenda_tracks::Tracks::<Test, ()>::set(group, sub_track, Some(track_info));
+    fc_pallet_referenda_tracks::OriginToTrackId::<Test, ()>::set(
+        community_origin_caller.clone(),
+        Some(track_id),
+    );
+    fc_pallet_referenda_tracks::TrackIdToOrigin::<Test, ()>::set(
+        track_id,
+        Some(community_origin_caller.clone()),
+    );
+
+    // Need a funded account to submit and deposit
+    let submitter = account(99);
+    assert_ok!(Balances::force_set_balance(
+        RuntimeOrigin::root(),
+        submitter.clone(),
+        100
+    ));
+
+    // Create a dummy proposal call
+    let call: RuntimeCall = crate::Call::<Test>::set_decision_method {
+        community_id,
+        decision_method: DecisionMethod::Membership,
+    }
+    .into();
+    let proposal = BoundedCallOf::<Test, ()>::Inline(BoundedVec::truncate_from(call.encode()));
+
+    assert_ok!(Referenda::submit(
+        RuntimeOrigin::signed(submitter.clone()),
+        Box::new(community_origin_caller),
+        proposal,
+        frame_support::traits::schedule::DispatchTime::After(1),
+    ));
+
+    // Find the poll index from events
+    let poll_index = 0u32; // First referendum
+
+    assert_ok!(Referenda::place_decision_deposit(
+        RuntimeOrigin::signed(submitter),
+        poll_index
+    ));
+
+    // Advance to decision phase
+    System::set_block_number(System::block_number() + 1);
+    Referenda::on_initialize(System::block_number());
+    Scheduler::on_initialize(System::block_number());
+
+    poll_index
+}
+
+fn anon_origin(community_id: CommunityId, rank: GenericRank, nullifier: H256) -> RuntimeOrigin {
+    let mut raw = crate::origin::RawOrigin::<Test>::new(community_id);
+    raw.with_subset(crate::origin::Subset::AnonymousMember { rank, nullifier });
+    raw.into()
+}
+
+#[test]
+fn test_named_vote_still_works() {
+    let alice = account(1);
+
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .add_member(COMMUNITY, alice.clone())
+        .build()
+        .execute_with(|| {
+            let poll_index = setup_poll(COMMUNITY);
+
+            // Named vote should work
+            assert_ok!(Communities::vote(
+                RuntimeOrigin::signed(alice.clone()),
+                poll_index,
+                Vote::Standard(true),
+            ));
+
+            // Verify vote was recorded with hash of account as key
+            let voter_key = BlakeTwo256::hash_of(&alice);
+            assert!(CommunityVotes::<Test>::get(poll_index, &voter_key).is_some());
+
+            // Verify event
+            System::assert_has_event(
+                crate::Event::<Test>::VoteCasted {
+                    who: Some(alice.clone()),
+                    poll_index,
+                    vote: Vote::Standard(true),
+                }
+                .into(),
+            );
+        });
+}
+
+#[test]
+fn test_anonymous_vote_uses_nullifier_key() {
+    let alice = account(1);
+
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .add_member(COMMUNITY, alice.clone())
+        .build()
+        .execute_with(|| {
+            let poll_index = setup_poll(COMMUNITY);
+            let nullifier = H256::from_low_u64_be(42);
+
+            // Anonymous vote with membership decision method
+            let origin = anon_origin(COMMUNITY, GenericRank::default(), nullifier);
+            assert_ok!(Communities::vote(
+                origin,
+                poll_index,
+                Vote::Standard(true),
+            ));
+
+            // Verify vote was recorded with hash of nullifier as key
+            let voter_key = BlakeTwo256::hash_of(&nullifier);
+            let (vote, multiplied) = CommunityVotes::<Test>::get(poll_index, &voter_key)
+                .expect("vote should be stored");
+            assert_eq!(vote, Vote::Standard(true));
+            assert_eq!(multiplied, 1); // membership = 1x multiplier
+
+            // Verify event has None for who (anonymous)
+            System::assert_has_event(
+                crate::Event::<Test>::VoteCasted {
+                    who: None,
+                    poll_index,
+                    vote: Vote::Standard(true),
+                }
+                .into(),
+            );
+        });
+}
+
+#[test]
+fn test_anonymous_vote_with_rank() {
+    let alice = account(1);
+
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .add_member(COMMUNITY, alice.clone())
+        .build()
+        .execute_with(|| {
+            // Set decision method to Rank
+            CommunityDecisionMethod::<Test>::set(COMMUNITY, DecisionMethod::Rank);
+
+            let poll_index = setup_poll(COMMUNITY);
+            let nullifier = H256::from_low_u64_be(100);
+            let rank = GenericRank::from(3u8);
+
+            let origin = anon_origin(COMMUNITY, rank, nullifier);
+            assert_ok!(Communities::vote(
+                origin,
+                poll_index,
+                Vote::Standard(true),
+            ));
+
+            // Verify the multiplied weight reflects rank
+            let voter_key = BlakeTwo256::hash_of(&nullifier);
+            let (_, multiplied) = CommunityVotes::<Test>::get(poll_index, &voter_key)
+                .expect("vote should be stored");
+            // rank 3 * vote weight 1 = 3
+            assert_eq!(multiplied, 3);
+        });
+}
+
+#[test]
+fn test_anonymous_vote_token_weighted_rejected() {
+    let alice = account(1);
+
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .add_member(COMMUNITY, alice.clone())
+        .build()
+        .execute_with(|| {
+            // Set decision method to NativeToken
+            CommunityDecisionMethod::<Test>::set(COMMUNITY, DecisionMethod::NativeToken);
+
+            let poll_index = setup_poll(COMMUNITY);
+            let nullifier = H256::from_low_u64_be(200);
+
+            // Anonymous vote with NativeToken should fail
+            let origin = anon_origin(COMMUNITY, GenericRank::default(), nullifier);
+            assert_noop!(
+                Communities::vote(
+                    origin,
+                    poll_index,
+                    Vote::Standard(true),
+                ),
+                Error::InvalidVoteType
+            );
+        });
+}
+
+#[test]
+fn test_anonymous_vote_duplicate_nullifier_rejected() {
+    let alice = account(1);
+
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .add_member(COMMUNITY, alice.clone())
+        .build()
+        .execute_with(|| {
+            let poll_index = setup_poll(COMMUNITY);
+            let nullifier = H256::from_low_u64_be(300);
+
+            // First anonymous vote succeeds
+            let origin = anon_origin(COMMUNITY, GenericRank::default(), nullifier);
+            assert_ok!(Communities::vote(
+                origin,
+                poll_index,
+                Vote::Standard(true),
+            ));
+
+            // Second anonymous vote with same nullifier should fail (AlreadyOngoing)
+            let origin2 = anon_origin(COMMUNITY, GenericRank::default(), nullifier);
+            assert_noop!(
+                Communities::vote(
+                    origin2,
+                    poll_index,
+                    Vote::Standard(false),
+                ),
+                Error::AlreadyOngoing
+            );
+        });
+}
+
+#[test]
+fn test_anonymous_vote_different_nullifiers_both_counted() {
+    let alice = account(1);
+
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .add_member(COMMUNITY, alice.clone())
+        .build()
+        .execute_with(|| {
+            let poll_index = setup_poll(COMMUNITY);
+            let nullifier1 = H256::from_low_u64_be(400);
+            let nullifier2 = H256::from_low_u64_be(401);
+
+            // Two different anonymous voters should both succeed
+            let origin1 = anon_origin(COMMUNITY, GenericRank::default(), nullifier1);
+            assert_ok!(Communities::vote(
+                origin1,
+                poll_index,
+                Vote::Standard(true),
+            ));
+
+            let origin2 = anon_origin(COMMUNITY, GenericRank::default(), nullifier2);
+            assert_ok!(Communities::vote(
+                origin2,
+                poll_index,
+                Vote::Standard(false),
+            ));
+
+            // Both votes should be stored
+            let key1 = BlakeTwo256::hash_of(&nullifier1);
+            let key2 = BlakeTwo256::hash_of(&nullifier2);
+            assert!(CommunityVotes::<Test>::get(poll_index, &key1).is_some());
+            assert!(CommunityVotes::<Test>::get(poll_index, &key2).is_some());
+
+            // Check tally via Polling
+            use frame_support::traits::Polling;
+            let (tally, _) = Referenda::as_ongoing(poll_index).expect("poll should be ongoing");
+            assert_eq!(tally.ayes, 1);
+            assert_eq!(tally.nays, 1);
+            assert_eq!(tally.bare_ayes, 1);
         });
 }

--- a/pallets/communities/src/tests/mod.rs
+++ b/pallets/communities/src/tests/mod.rs
@@ -1,13 +1,246 @@
-use frame_support::assert_ok;
+use frame_support::{assert_noop, assert_ok};
+use sp_runtime::traits::BlakeTwo256;
 
-mod helpers;
+use frame_contrib_traits::memberships::GenericRank;
 
 use crate::mock::*;
-use helpers::*;
+use crate::types::*;
+use crate::{MemberCount, Members, MerkleRoot, SubRoots, RanksTotal};
 
 type Error = crate::Error<Test>;
 
-mod governance;
-mod membership;
-mod registry;
-mod weights;
+#[test]
+fn test_add_remove_member() {
+    let alice = account(1);
+    let bob = account(2);
+
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .build()
+        .execute_with(|| {
+            let origin = community_origin(COMMUNITY);
+
+            // Add alice
+            assert_ok!(Communities::add_member(origin.clone(), alice.clone(), None, None));
+            assert!(Members::<Test>::get(COMMUNITY, &alice).is_some());
+            assert_eq!(MemberCount::<Test>::get(COMMUNITY), 1);
+
+            // Add bob
+            assert_ok!(Communities::add_member(origin.clone(), bob.clone(), None, None));
+            assert_eq!(MemberCount::<Test>::get(COMMUNITY), 2);
+
+            // Cannot add alice again
+            assert_noop!(
+                Communities::add_member(origin.clone(), alice.clone(), None, None),
+                Error::AlreadyMember
+            );
+
+            // Remove alice
+            assert_ok!(Communities::remove_member(origin.clone(), alice.clone()));
+            assert!(Members::<Test>::get(COMMUNITY, &alice).is_none());
+            assert_eq!(MemberCount::<Test>::get(COMMUNITY), 1);
+
+            // Cannot remove alice again
+            assert_noop!(
+                Communities::remove_member(origin.clone(), alice.clone()),
+                Error::NotAMember
+            );
+        });
+}
+
+#[test]
+fn test_add_member_with_rank_and_role() {
+    let alice = account(1);
+
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .build()
+        .execute_with(|| {
+            let origin = community_origin(COMMUNITY);
+
+            assert_ok!(Communities::add_member(
+                origin.clone(),
+                alice.clone(),
+                Some(GenericRank::from(3u8)),
+                Some(Role::Admin),
+            ));
+
+            let record = Members::<Test>::get(COMMUNITY, &alice).unwrap();
+            assert_eq!(record.role, Role::Admin);
+            let rank_val: u32 = record.rank.into();
+            assert_eq!(rank_val, 3);
+            assert_eq!(RanksTotal::<Test>::get(COMMUNITY), 3);
+        });
+}
+
+#[test]
+fn test_suspend_member() {
+    let alice = account(1);
+
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .add_member(COMMUNITY, alice.clone())
+        .build()
+        .execute_with(|| {
+            let origin = community_origin(COMMUNITY);
+            assert_eq!(MemberCount::<Test>::get(COMMUNITY), 1);
+
+            // Suspend alice
+            assert_ok!(Communities::suspend_member(origin.clone(), alice.clone()));
+
+            let record = Members::<Test>::get(COMMUNITY, &alice).unwrap();
+            assert_eq!(record.status, MemberStatus::Suspended);
+            assert_eq!(record.nonce, 1);
+            // Suspended members don't count
+            assert_eq!(MemberCount::<Test>::get(COMMUNITY), 0);
+
+            // Cannot suspend again
+            assert_noop!(
+                Communities::suspend_member(origin.clone(), alice.clone()),
+                Error::MemberIsSuspended
+            );
+        });
+}
+
+#[test]
+fn test_merkle_root_updates() {
+    let alice = account(1);
+    let bob = account(2);
+
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .build()
+        .execute_with(|| {
+            let origin = community_origin(COMMUNITY);
+
+            // No root initially
+            assert!(MerkleRoot::<Test>::get(COMMUNITY).is_none());
+
+            // Add alice, root should be set
+            assert_ok!(Communities::add_member(origin.clone(), alice.clone(), None, None));
+            let root1 = MerkleRoot::<Test>::get(COMMUNITY);
+            assert!(root1.is_some());
+
+            // Add bob, root should change
+            assert_ok!(Communities::add_member(origin.clone(), bob.clone(), None, None));
+            let root2 = MerkleRoot::<Test>::get(COMMUNITY);
+            assert!(root2.is_some());
+            assert_ne!(root1, root2);
+
+            // Remove alice, root should change
+            assert_ok!(Communities::remove_member(origin.clone(), alice.clone()));
+            let root3 = MerkleRoot::<Test>::get(COMMUNITY);
+            assert!(root3.is_some());
+            assert_ne!(root2, root3);
+
+            // Remove bob, root should be removed (no active members)
+            assert_ok!(Communities::remove_member(origin.clone(), bob.clone()));
+            assert!(MerkleRoot::<Test>::get(COMMUNITY).is_none());
+        });
+}
+
+#[test]
+fn test_private_community_root_update() {
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Private)
+        .build()
+        .execute_with(|| {
+            let origin = community_origin(COMMUNITY);
+
+            let fake_root = <BlakeTwo256 as sp_runtime::traits::Hash>::hash_of(b"test_root");
+
+            assert_ok!(Communities::update_membership_root(
+                origin.clone(),
+                fake_root,
+                42,
+            ));
+
+            assert_eq!(MerkleRoot::<Test>::get(COMMUNITY), Some(fake_root));
+            assert_eq!(MemberCount::<Test>::get(COMMUNITY), 42);
+        });
+}
+
+#[test]
+fn test_cannot_update_root_on_public_community() {
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .build()
+        .execute_with(|| {
+            let origin = community_origin(COMMUNITY);
+            let fake_root = <BlakeTwo256 as sp_runtime::traits::Hash>::hash_of(b"test_root");
+
+            assert_noop!(
+                Communities::update_membership_root(origin.clone(), fake_root, 10),
+                Error::CommunityIsPublic
+            );
+        });
+}
+
+#[test]
+fn test_cannot_add_member_to_private_community() {
+    let alice = account(1);
+
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Private)
+        .build()
+        .execute_with(|| {
+            let origin = community_origin(COMMUNITY);
+
+            assert_noop!(
+                Communities::add_member(origin.clone(), alice.clone(), None, None),
+                Error::CommunityIsPrivate
+            );
+        });
+}
+
+#[test]
+fn test_sub_root_update() {
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Private)
+        .build()
+        .execute_with(|| {
+            let origin = community_origin(COMMUNITY);
+            let fake_root = <BlakeTwo256 as sp_runtime::traits::Hash>::hash_of(b"sub_root");
+
+            assert_ok!(Communities::update_sub_root(origin.clone(), 42, fake_root));
+            assert_eq!(SubRoots::<Test>::get(COMMUNITY, 42), Some(fake_root));
+        });
+}
+
+#[test]
+fn test_role_default_is_member() {
+    let alice = account(1);
+
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .add_member(COMMUNITY, alice.clone())
+        .build()
+        .execute_with(|| {
+            let record = Members::<Test>::get(COMMUNITY, &alice).unwrap();
+            assert_eq!(record.role, Role::Member);
+        });
+}
+
+#[test]
+fn test_promote_demote_updates_merkle_root() {
+    let alice = account(1);
+
+    TestEnvBuilder::new()
+        .add_community(COMMUNITY, PrivacyLevel::Public)
+        .add_member(COMMUNITY, alice.clone())
+        .build()
+        .execute_with(|| {
+            let origin = community_origin(COMMUNITY);
+            let root_before = MerkleRoot::<Test>::get(COMMUNITY);
+
+            assert_ok!(Communities::promote(origin.clone(), alice.clone()));
+            let root_after_promote = MerkleRoot::<Test>::get(COMMUNITY);
+            assert_ne!(root_before, root_after_promote);
+
+            assert_ok!(Communities::demote(origin.clone(), alice.clone()));
+            let root_after_demote = MerkleRoot::<Test>::get(COMMUNITY);
+            assert_ne!(root_after_promote, root_after_demote);
+            // After demote back to 0, should match original root
+            assert_eq!(root_before, root_after_demote);
+        });
+}

--- a/pallets/communities/src/types.rs
+++ b/pallets/communities/src/types.rs
@@ -72,6 +72,27 @@ pub enum MemberStatus {
     Suspended,
 }
 
+/// Role of a community member
+#[derive(
+    Clone,
+    Debug,
+    Decode,
+    DecodeWithMemTracking,
+    Default,
+    Encode,
+    Eq,
+    MaxEncodedLen,
+    PartialEq,
+    TypeInfo,
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum Role {
+    Admin,
+    Manager,
+    #[default]
+    Member,
+}
+
 /// A member's on-chain record
 #[derive(
     Clone,
@@ -89,6 +110,7 @@ pub struct MemberRecord {
     pub rank: GenericRank,
     pub nonce: u32,
     pub status: MemberStatus,
+    pub role: Role,
 }
 
 /// Gas/transaction budget for a community per session

--- a/pallets/communities/src/types.rs
+++ b/pallets/communities/src/types.rs
@@ -256,13 +256,32 @@ impl<T> Default for Tally<T> {
 impl<T: Config> Tally<T> {
     pub(crate) fn max_support(community_id: CommunityIdOf<T>) -> VoteWeight {
         match CommunityDecisionMethod::<T>::get(community_id) {
-            DecisionMethod::Membership => crate::MemberCount::<T>::get(community_id),
+            DecisionMethod::Membership => membership_denominator::<T>(community_id),
             DecisionMethod::Rank => crate::RanksTotal::<T>::get(community_id),
             DecisionMethod::NativeToken => {
                 T::Balances::total_issuance().saturated_into::<VoteWeight>()
             }
             DecisionMethod::CommunityAsset(asset_id, _) => {
                 T::Assets::total_issuance(asset_id).saturated_into::<VoteWeight>()
+            }
+        }
+    }
+}
+
+/// Denominator for `DecisionMethod::Membership` support.
+/// - Public: the on-chain [`crate::MemberCount`], which the admin cannot set arbitrarily.
+/// - Private/Hybrid: the admin-declared [`crate::ClaimedSupport`]. If never set, falls
+///   back to the on-chain member count so freshly-bootstrapped communities don't render
+///   referenda unreachable.
+fn membership_denominator<T: Config>(community_id: CommunityIdOf<T>) -> VoteWeight {
+    match crate::Info::<T>::get(community_id).map(|i| i.privacy) {
+        Some(crate::PrivacyLevel::Public) | None => crate::MemberCount::<T>::get(community_id),
+        Some(_) => {
+            let declared = crate::ClaimedSupport::<T>::get(community_id);
+            if declared > 0 {
+                declared
+            } else {
+                crate::MemberCount::<T>::get(community_id)
             }
         }
     }

--- a/pallets/communities/src/types.rs
+++ b/pallets/communities/src/types.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 use crate::{CommunityDecisionMethod, Config};
-use frame_contrib_traits::memberships::{Inspect, Rank};
+use frame_contrib_traits::memberships::GenericRank;
 
 use frame_support::traits::{
     fungible::{self, Inspect as FunInspect},
@@ -23,7 +23,6 @@ pub type PollIndexOf<T> = <<T as Config>::Polls as Polling<Tally<T>>>::Index;
 pub type AccountIdLookupOf<T> = <<T as frame_system::Config>::Lookup as StaticLookup>::Source;
 pub type PalletsOriginOf<T> =
     <<T as frame_system::Config>::RuntimeOrigin as OriginTrait>::PalletsOrigin;
-pub type MembershipIdOf<T> = <T as Config>::MembershipId;
 pub type RuntimeCallFor<T> = <T as frame_system::Config>::RuntimeCall;
 pub type RuntimeOriginFor<T> = <T as frame_system::Config>::RuntimeOrigin;
 pub type BlockNumberFor<T> =
@@ -31,6 +30,86 @@ pub type BlockNumberFor<T> =
 
 #[cfg(feature = "runtime-benchmarks")]
 pub type BenchmarkHelperOf<T> = <T as Config>::BenchmarkHelper;
+
+/// Privacy level determines what membership data is stored on-chain
+#[derive(
+    Clone,
+    Debug,
+    Decode,
+    DecodeWithMemTracking,
+    Default,
+    Encode,
+    Eq,
+    MaxEncodedLen,
+    PartialEq,
+    TypeInfo,
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum PrivacyLevel {
+    #[default]
+    Public,
+    Private,
+    Hybrid,
+}
+
+/// Status of a community member
+#[derive(
+    Clone,
+    Debug,
+    Decode,
+    DecodeWithMemTracking,
+    Default,
+    Encode,
+    Eq,
+    MaxEncodedLen,
+    PartialEq,
+    TypeInfo,
+)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum MemberStatus {
+    #[default]
+    Active,
+    Suspended,
+}
+
+/// A member's on-chain record
+#[derive(
+    Clone,
+    Debug,
+    Decode,
+    DecodeWithMemTracking,
+    Default,
+    Encode,
+    Eq,
+    MaxEncodedLen,
+    PartialEq,
+    TypeInfo,
+)]
+pub struct MemberRecord {
+    pub rank: GenericRank,
+    pub nonce: u32,
+    pub status: MemberStatus,
+}
+
+/// Gas/transaction budget for a community per session
+#[derive(
+    Clone,
+    Debug,
+    Decode,
+    DecodeWithMemTracking,
+    Default,
+    Encode,
+    Eq,
+    MaxEncodedLen,
+    PartialEq,
+    TypeInfo,
+)]
+pub struct CommunityBudget<BlockNumber> {
+    pub capacity: u64,
+    pub used: u64,
+    pub session_start: BlockNumber,
+    pub session_length: BlockNumber,
+}
 
 /// The Community struct holds the basic definition of a community. It includes
 /// the current state of a community, the [`AccountId`][1] for the community
@@ -42,6 +121,10 @@ pub type BenchmarkHelperOf<T> = <T as Config>::BenchmarkHelper;
 pub struct CommunityInfo {
     /// The current state of the community.
     pub state: CommunityState,
+    /// The privacy level of the community.
+    pub privacy: PrivacyLevel,
+    /// Maximum number of members.
+    pub capacity: u32,
 }
 
 /// The current state of the community. It represents whether a community
@@ -151,8 +234,8 @@ impl<T> Default for Tally<T> {
 impl<T: Config> Tally<T> {
     pub(crate) fn max_support(community_id: CommunityIdOf<T>) -> VoteWeight {
         match CommunityDecisionMethod::<T>::get(community_id) {
-            DecisionMethod::Membership => T::MemberMgmt::members_total(&community_id),
-            DecisionMethod::Rank => T::MemberMgmt::ranks_total(&community_id),
+            DecisionMethod::Membership => crate::MemberCount::<T>::get(community_id),
+            DecisionMethod::Rank => crate::RanksTotal::<T>::get(community_id),
             DecisionMethod::NativeToken => {
                 T::Balances::total_issuance().saturated_into::<VoteWeight>()
             }
@@ -191,15 +274,8 @@ pub trait BenchmarkHelper<T: Config> {
         u8::MAX as u32
     }
 
-    /// Initializes the membership collection of a community.
-    fn initialize_memberships_collection() -> Result<(), frame_benchmarking::BenchmarkError>;
-
-    /// Extends the membership collection of a community with a given
-    /// membership ID.
-    fn issue_membership(
-        community_id: CommunityIdOf<T>,
-        membership_id: MembershipIdOf<T>,
-    ) -> Result<(), frame_benchmarking::BenchmarkError>;
+    /// Sets up members for benchmarking
+    fn setup_members(community_id: CommunityIdOf<T>, count: u32) -> Result<(), BenchmarkError>;
 
     /// This method prepares the referenda track to be used
     /// to submit the poll, for benchmarking purposes.

--- a/pallets/communities/src/verifier.rs
+++ b/pallets/communities/src/verifier.rs
@@ -43,9 +43,11 @@ where
         proof: &Self::Proof,
         public_inputs: &Self::PublicInputs,
     ) -> Result<(), VerifyError> {
+        // `H::Output: Copy` for all substrate hashers we care about, so the iterator-based
+        // form avoids the otherwise-needless clone of the siblings vec.
         let valid = binary_merkle_tree::verify_proof::<H, _, _>(
             &public_inputs.root,
-            proof.siblings.clone(),
+            proof.siblings.iter().copied(),
             proof.leaf_count,
             proof.leaf_index,
             &proof.leaf,

--- a/pallets/communities/src/verifier.rs
+++ b/pallets/communities/src/verifier.rs
@@ -1,0 +1,59 @@
+//! Default merkle proof verifier for membership proofs.
+
+use alloc::vec::Vec;
+use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
+use fc_traits_proof_verifier::{ProofVerifier, VerifyError};
+use scale_info::TypeInfo;
+use sp_runtime::traits::Hash;
+
+/// Merkle inclusion proof
+#[derive(Clone, Debug, Encode, Decode, DecodeWithMemTracking, PartialEq, Eq, TypeInfo)]
+pub struct MerkleProof<H: Hash> {
+    /// The leaf hash
+    pub leaf: H::Output,
+    /// Proof siblings
+    pub siblings: Vec<H::Output>,
+    /// Leaf index in the tree
+    pub leaf_index: u32,
+    /// Total number of leaves
+    pub leaf_count: u32,
+}
+
+/// Public inputs for membership proof verification
+#[derive(Clone, Debug, Encode, Decode, DecodeWithMemTracking, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
+pub struct MembershipInputs<H: Hash> {
+    /// The merkle root to verify against
+    pub root: H::Output,
+}
+
+/// Simple merkle inclusion proof verifier (no ZK).
+/// Uses binary-merkle-tree for verification.
+pub struct MerkleVerifier<H>(core::marker::PhantomData<H>);
+
+impl<H: Hash + scale_info::TypeInfo + 'static> ProofVerifier for MerkleVerifier<H>
+where
+    H::Output: Ord + Default,
+{
+    type Proof = MerkleProof<H>;
+    type PublicInputs = MembershipInputs<H>;
+    type ProgramId = (); // no program selection needed
+
+    fn verify(
+        _program: &Self::ProgramId,
+        proof: &Self::Proof,
+        public_inputs: &Self::PublicInputs,
+    ) -> Result<(), VerifyError> {
+        let valid = binary_merkle_tree::verify_proof::<H, _, _>(
+            &public_inputs.root,
+            proof.siblings.clone(),
+            proof.leaf_count,
+            proof.leaf_index,
+            &proof.leaf,
+        );
+        if valid {
+            Ok(())
+        } else {
+            Err(VerifyError::InvalidProof)
+        }
+    }
+}

--- a/pallets/communities/src/weights.rs
+++ b/pallets/communities/src/weights.rs
@@ -46,6 +46,7 @@ pub trait WeightInfo {
 	fn suspend_member() -> Weight { Weight::zero() }
 	fn update_membership_root() -> Weight { Weight::zero() }
 	fn update_sub_root() -> Weight { Weight::zero() }
+	fn set_budget() -> Weight { Weight::zero() }
 }
 
 /// Weights for pallet_communities using the Substrate node and recommended hardware.

--- a/pallets/communities/src/weights.rs
+++ b/pallets/communities/src/weights.rs
@@ -43,6 +43,9 @@ pub trait WeightInfo {
 	fn remove_vote() -> Weight;
 	fn unlock() -> Weight;
 	fn dispatch_as_account() -> Weight;
+	fn suspend_member() -> Weight { Weight::zero() }
+	fn update_membership_root() -> Weight { Weight::zero() }
+	fn update_sub_root() -> Weight { Weight::zero() }
 }
 
 /// Weights for pallet_communities using the Substrate node and recommended hardware.

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -12,6 +12,7 @@ fc-traits-gas-tank.workspace = true
 fc-traits-listings.workspace = true
 fc-traits-memberships.workspace = true
 fc-traits-payments.workspace = true
+fc-traits-proof-verifier.workspace = true
 
 [features]
 default = ["std"]
@@ -21,6 +22,7 @@ std = [
 	"fc-traits-listings/std",
 	"fc-traits-memberships/std",
 	"fc-traits-payments/std",
+	"fc-traits-proof-verifier/std",
 ]
 runtime-benchmarks = [
 	"fc-traits-gas-tank/runtime-benchmarks",

--- a/traits/proof-verifier/Cargo.toml
+++ b/traits/proof-verifier/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+name = "fc-traits-proof-verifier"
+repository.workspace = true
+version = "0.1.0"
+
+[dependencies]
+codec = { workspace = true, features = ["derive"] }
+frame-support.workspace = true
+scale-info = { workspace = true, features = ["derive"] }
+sp-runtime.workspace = true
+
+[features]
+default = ["std"]
+std = [
+  "codec/std",
+  "frame-support/std",
+  "scale-info/std",
+  "sp-runtime/std",
+]

--- a/traits/proof-verifier/src/lib.rs
+++ b/traits/proof-verifier/src/lib.rs
@@ -1,0 +1,46 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use frame_support::Parameter;
+use sp_runtime::DispatchError;
+
+/// Error from proof verification
+#[derive(Debug, PartialEq, Eq)]
+pub enum VerifyError {
+    /// The proof is invalid
+    InvalidProof,
+    /// The program/verification key is not registered
+    UnknownProgram,
+    /// Public inputs are malformed
+    InvalidInputs,
+}
+
+impl From<VerifyError> for DispatchError {
+    fn from(e: VerifyError) -> Self {
+        match e {
+            VerifyError::InvalidProof => DispatchError::Other("InvalidProof"),
+            VerifyError::UnknownProgram => DispatchError::Other("UnknownProgram"),
+            VerifyError::InvalidInputs => DispatchError::Other("InvalidInputs"),
+        }
+    }
+}
+
+/// General-purpose proof verification trait.
+///
+/// Implementations can range from simple merkle inclusion proofs to
+/// full ZK proof verification (e.g. stwo STARKs via a PVM zkVM).
+pub trait ProofVerifier {
+    /// The proof blob
+    type Proof: Parameter;
+    /// Public inputs/outputs visible to the verifier
+    type PublicInputs: Parameter;
+    /// Identifies the verification program (e.g. verification key, circuit ID).
+    /// Use `()` for verifiers that don't need program selection.
+    type ProgramId: Parameter;
+
+    /// Verify a proof for the given program and public inputs.
+    fn verify(
+        program: &Self::ProgramId,
+        proof: &Self::Proof,
+        public_inputs: &Self::PublicInputs,
+    ) -> Result<(), VerifyError>;
+}

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -8,3 +8,4 @@ pub use fc_traits_gas_tank as gas_tank;
 pub use fc_traits_listings as listings;
 pub use fc_traits_memberships as memberships;
 pub use fc_traits_payments as payments;
+pub use fc_traits_proof_verifier as proof_verifier;


### PR DESCRIPTION
## Summary

Rework pallet-communities to support privacy-preserving communities. Replaces NFT-based memberships with built-in storage and merkle tree commitments for anonymous membership proofs.

Closes virto-network/kreivo#474

## Changes

### Commit 1: New storage model
- Replace external `MemberMgmt` trait (pallet-nfts backed) with built-in `Members` storage
- New types: `PrivacyLevel` (Public/Private/Hybrid), `MemberRecord`, `MemberStatus`, `CommunityBudget`
- New storage: `MerkleRoot`, `SubRoots`, `MemberCount`, `RanksTotal`, `Members`, `Budget`
- Config: removed `MembershipId`/`MemberMgmt`, added `Hasher`/`MaxMembers`
- `vote()` no longer takes `membership_id` — uses account-based lookup

### Commit 2: Member management with roles
- `Role` enum (Admin/Manager/Member) in `MemberRecord`
- `add_member` accepts optional rank and role
- New extrinsics: `suspend_member`, `update_membership_root`, `update_sub_root`
- Automatic merkle root recomputation for public communities on every member change
- Privacy enforcement: private communities reject `add_member`, public reject `update_membership_root`

### Commit 3: Community-level gas budget
- `set_budget` extrinsic with capacity and session length
- `check_budget`/`burn_budget`/`refund_budget` public helpers for runtime gas payment integration
- Session-based auto-renewal when period expires

### Commit 4: Anonymous membership transaction extension
- `AnonymousMembership<T>` tx extension verifies merkle inclusion proofs
- Nullifier tracking prevents double-actions (e.g. double-voting)
- Produces anonymous `CommunityMember` origin with rank as public input
- New `Subset::AnonymousMember` origin variant

### Commit 5: Private voting
- `vote()` dual-path: named (signed) and anonymous (community origin)
- Hash-based voter keys work for both paths
- Rank from proof's public inputs used as vote multiplier
- Token-weighted voting rejected for anonymous origins
- Anonymous votes cannot be removed
- Public tally preserved

## Design decisions

- **MVP without ZK**: Simple merkle inclusion proofs with nullifier scheme. Designed for easy upgrade to ZK (stwo stark verifier coming)
- **Leaf structure**: `hash(who || community_id || rank || nonce)` — nonce invalidates old proofs on changes
- **Nullifier**: `hash(identity_secret, action_scope)` — deterministic per member per action
- **Gas model**: Community-level budget (like org-level usage), not per-member
- **Anonymous + pallet-pass**: Mutually exclusive — anonymous proofs are the sole authentication

## Test coverage

24 tests covering:
- Member add/remove/suspend lifecycle
- Role-based permissions
- Merkle root computation and verification
- Privacy level enforcement
- Budget set/check/burn/session-reset/exhaustion
- Nullifier replay prevention
- Named and anonymous voting paths
- Rank-weighted anonymous voting
- Token-weighted voting rejection for anonymous

## Migration

This is a breaking change. Kreivo runtime will need storage migrations from NFT-based memberships to the new model (tracked separately).

## Follow-up work

- [ ] Re-enable benchmarking module with new extrinsics
- [ ] CommunityId u16→u32 migration (kreivo)
- [ ] Remove communities-manager pallet (kreivo)
- [ ] ZK proof verification (replace merkle inclusion with stark proofs)
- [ ] Encrypted tally for fully private voting (homomorphic encryption)
- [ ] Vote multiplier calculator integration (kreivo#476)